### PR TITLE
Neues Feld auszahlungsDatum am Annu

### DIFF
--- a/Dokumentation/index.html
+++ b/Dokumentation/index.html
@@ -2442,6 +2442,11 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-middle"><p class="tableblock"><strong>auszahlungsDatum</strong><br>
+<em>optional</em></p></td>
+<td class="tableblock halign-left valign-middle"><p class="tableblock">string (date)</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-middle"><p class="tableblock"><strong>bereitstellungsZinsFreieZeitInMonaten</strong><br>
 <em>optional</em></p></td>
 <td class="tableblock halign-left valign-middle"><p class="tableblock">integer (int32)</p></td>

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -800,6 +800,9 @@ definitions:
     required:
     - "tilgungsWunsch"
     properties:
+      auszahlungsDatum:
+        type: "string"
+        format: "date"
       bereitstellungsZinsFreieZeitInMonaten:
         type: "integer"
         format: "int32"


### PR DESCRIPTION
Eigentlich sollte das Feld aus Forward nach Annu verschoben werden. Sollte aber bestimmt vorerst in beiden Klassen bleiben, wegen Rückwärtskompatibilität? 