### PR TITLE
Boyscouting - Absolute Links zu Swagger-Dateien

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Wesentliche Änderungen zur Version 1.5.
 
 ### Swagger Spezifikation
 
-Die API ist vollständig in Swagger definiert. Die Swagger Definition wird im YAML-Format zur Verfügung gestellt.: [swagger.yaml](swagger.yaml)
+Die API ist vollständig in Swagger definiert. Die Swagger Definition wird im YAML-Format zur Verfügung gestellt.: [swagger.yaml](https://raw.githubusercontent.com/europace/baufismart-angebote-api/master/swagger.yaml)
 
 Diese Spezifikation kann auch zur Generierung von Clients für diese API verwendet
 werden. Dazu empfehlen wir das Tool [Swagger Codegen](https://github.com/swagger-api/swagger-codegen). 


### PR DESCRIPTION
Auf https://developer.europace.de/api/ergebnislisten/ führt der relativen Link für die Swagger-Datei ins Nirvana.
Aufgrund dessen wurden hier die absoluten Pfade eingetragen.