### PR TITLE
Bugfix/swagger spec 302

### DIFF
--- a/Dokumentation/index.html
+++ b/Dokumentation/index.html
@@ -594,7 +594,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="sect2">
 <h3 id="_aktuelle_version">1.1. Aktuelle Version</h3>
 <div class="paragraph">
-<p><em>Version</em> : 2.6.1</p>
+<p><em>Version</em> : 2.6.2</p>
 </div>
 </div>
 <div class="sect2">
@@ -685,6 +685,22 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </tr>
 </thead>
 <tbody>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Header</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>X-TraceId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Eine eindeutige technische Id zur Identifikation des Requests.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+</tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>Query</strong></p>
@@ -924,6 +940,22 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </tr>
 </thead>
 <tbody>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Header</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>X-TraceId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Eine eindeutige technische Id zur Identifikation des Requests.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+</tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>Path</strong></p>
@@ -1166,6 +1198,22 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Header</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>X-TraceId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Eine eindeutige technische Id zur Identifikation des Requests.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>Query</strong></p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
@@ -1283,13 +1331,13 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p><strong>200</strong></p>
+<p><strong>302</strong></p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p>OK</p>
+<p>Die Ermittlung wurde erzeugt und ist maximal eine Stunde unter der Url im 'location' Header abrufbar. Beim Abruf der Ermittlung wird der Bearer Token zur Autorisierung erwartet.</p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
-<p><a href="#_ermittlung">Ermittlung</a></p>
+<p>Kein Inhalt</p>
 </div></div></td>
 </tr>
 <tr>
@@ -1445,6 +1493,21 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </tr>
 </thead>
 <tbody>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Header</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>X-TraceId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Eine eindeutige technische Id zur Identifikation des Requests.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+</tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>Path</strong></p>
@@ -1634,6 +1697,21 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Header</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>X-TraceId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Eine eindeutige technische Id zur Identifikation des Requests.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>Path</strong></p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
@@ -1819,6 +1897,21 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </tr>
 </thead>
 <tbody>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Header</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>X-TraceId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Eine eindeutige technische Id zur Identifikation des Requests.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+</tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>Path</strong></p>
@@ -2023,6 +2116,21 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Header</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>X-TraceId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Eine eindeutige technische Id zur Identifikation des Requests.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>Path</strong></p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
@@ -2225,6 +2333,22 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </tr>
 </thead>
 <tbody>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Header</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>X-TraceId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Eine eindeutige technische Id zur Identifikation des Requests.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"></div></td>
+</tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>Path</strong></p>
@@ -2449,6 +2573,21 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Header</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>X-TraceId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Eine eindeutige technische Id zur Identifikation des Requests.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>Path</strong></p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
@@ -2651,6 +2790,21 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Header</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>X-TraceId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Eine eindeutige technische Id zur Identifikation des Requests.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>Path</strong></p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
@@ -2851,6 +3005,21 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </tr>
 </thead>
 <tbody>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Header</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>X-TraceId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Eine eindeutige technische Id zur Identifikation des Requests.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+</tr>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>Path</strong></p>
@@ -3070,6 +3239,21 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Header</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>X-TraceId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Eine eindeutige technische Id zur Identifikation des Requests.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>Path</strong></p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
@@ -3257,6 +3441,21 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Header</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>X-TraceId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Eine eindeutige technische Id zur Identifikation des Requests.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
 <p><strong>Path</strong></p>
 </div></div></td>
 <td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
@@ -3423,6 +3622,42 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre>GET /version/baufiSmartApi</pre>
 </div>
+</div>
+<div class="sect4">
+<h5 id="_parameter_14">Parameter</h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 11.1111%;">
+<col style="width: 16.6666%;">
+<col style="width: 50%;">
+<col style="width: 22.2223%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-middle">Typ</th>
+<th class="tableblock halign-left valign-middle">Name</th>
+<th class="tableblock halign-left valign-middle">Beschreibung</th>
+<th class="tableblock halign-left valign-middle">Typ</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>Header</strong></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p><strong>X-TraceId</strong><br>
+<em>optional</em></p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>Eine eindeutige technische Id zur Identifikation des Requests.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-middle"><div class="content"><div class="paragraph">
+<p>string</p>
+</div></div></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect4">
 <h5 id="_antworten_14">Antworten</h5>
@@ -11617,7 +11852,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 Version 2.0<br>
-Last updated 2021-06-07 15:55:40 +0200
+Last updated 2021-07-15 18:14:02 +0200
 </div>
 </div>
 </body>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Eine API, um Finanzierungs-Angebote zu ermitteln
 
 ⚠️ Diese API hieß ehemals Finanzierungsvorschläge API oder Ergebnisslisten API (auch ELI genannt).
 
-##### Aktuelle Version: 2.6.1
+##### Aktuelle Version: 2.6.2
 
 Wesentliche Änderungen zur Version 1.5.
 

--- a/swagger.json
+++ b/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "Ein Service um eine Ergebnisliste mit Finanzierungsvorschlägen zu ermitteln",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "title": "Ergebnislisten API",
     "contact": {
       "name": "Europace AG",
@@ -47,6 +47,13 @@
           "application/json"
         ],
         "parameters": [
+          {
+            "name": "X-TraceId",
+            "in": "header",
+            "description": "Eine eindeutige technische Id zur Identifikation des Requests.",
+            "required": false,
+            "type": "string"
+          },
           {
             "name": "alternativen",
             "in": "query",
@@ -138,8 +145,7 @@
               "API"
             ]
           }
-        ],
-        "deprecated": false
+        ]
       }
     },
     "/v1/finanzierungsvorschlaege/{vorgangsNummer}": {
@@ -153,6 +159,13 @@
           "application/json"
         ],
         "parameters": [
+          {
+            "name": "X-TraceId",
+            "in": "header",
+            "description": "Eine eindeutige technische Id zur Identifikation des Requests.",
+            "required": false,
+            "type": "string"
+          },
           {
             "name": "alternativen",
             "in": "query",
@@ -236,8 +249,7 @@
               "API"
             ]
           }
-        ],
-        "deprecated": false
+        ]
       }
     },
     "/v2/ergebnisliste/ermittlung": {
@@ -249,6 +261,13 @@
         "description": "Als Parameter wird eine Vorgangsnummer oder der Vorgang als JSON im Body benötigt",
         "operationId": "ermittleErgebnisse",
         "parameters": [
+          {
+            "name": "X-TraceId",
+            "in": "header",
+            "description": "Eine eindeutige technische Id zur Identifikation des Requests.",
+            "required": false,
+            "type": "string"
+          },
           {
             "name": "alternativen",
             "in": "query",
@@ -304,11 +323,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/Ermittlung"
-            }
+          "302": {
+            "description": "Die Ermittlung wurde erzeugt und ist maximal eine Stunde unter der Url im 'location' Header abrufbar. Beim Abruf der Ermittlung wird der Bearer Token zur Autorisierung erwartet."
           },
           "400": {
             "description": "Bad Request",
@@ -365,8 +381,7 @@
               "API"
             ]
           }
-        ],
-        "deprecated": false
+        ]
       }
     },
     "/v2/ergebnisliste/ermittlung/{ermittlungsId}": {
@@ -378,6 +393,13 @@
         "description": "Als Parameter wird die ErmittlungsId benötigt.",
         "operationId": "getErmittlung",
         "parameters": [
+          {
+            "name": "X-TraceId",
+            "in": "header",
+            "description": "Eine eindeutige technische Id zur Identifikation des Requests.",
+            "required": false,
+            "type": "string"
+          },
           {
             "name": "ermittlungsId",
             "in": "path",
@@ -442,8 +464,7 @@
               "API"
             ]
           }
-        ],
-        "deprecated": false
+        ]
       }
     },
     "/v2/ergebnisliste/ermittlung/{ermittlungsId}/ergebnisse": {
@@ -455,6 +476,13 @@
         "description": "Als Parameter wird die ErmittlungsAnfrageId benötigt.",
         "operationId": "getErgebnisListe",
         "parameters": [
+          {
+            "name": "X-TraceId",
+            "in": "header",
+            "description": "Eine eindeutige technische Id zur Identifikation des Requests.",
+            "required": false,
+            "type": "string"
+          },
           {
             "name": "ermittlungsId",
             "in": "path",
@@ -519,8 +547,7 @@
               "API"
             ]
           }
-        ],
-        "deprecated": false
+        ]
       }
     },
     "/v2/ergebnisliste/ermittlung/{ermittlungsId}/ergebnisse/{ergebnisNummer}": {
@@ -532,6 +559,13 @@
         "description": "Als Parameter wird die ErmittlungsAnfrageId und der Ergebnisnummer benötigt.",
         "operationId": "getErgebnis",
         "parameters": [
+          {
+            "name": "X-TraceId",
+            "in": "header",
+            "description": "Eine eindeutige technische Id zur Identifikation des Requests.",
+            "required": false,
+            "type": "string"
+          },
           {
             "name": "ergebnisNummer",
             "in": "path",
@@ -604,8 +638,7 @@
               "API"
             ]
           }
-        ],
-        "deprecated": false
+        ]
       }
     },
     "/v2/ergebnisliste/ermittlung/{ermittlungsId}/ergebnisse/{ergebnisNummer}/meldungen": {
@@ -617,6 +650,13 @@
         "description": "Als Parameter wird die ErmittlungsAnfrageId und die Ergebnisnummer benötigt.",
         "operationId": "getMeldungen",
         "parameters": [
+          {
+            "name": "X-TraceId",
+            "in": "header",
+            "description": "Eine eindeutige technische Id zur Identifikation des Requests.",
+            "required": false,
+            "type": "string"
+          },
           {
             "name": "ergebnisNummer",
             "in": "path",
@@ -689,8 +729,7 @@
               "API"
             ]
           }
-        ],
-        "deprecated": false
+        ]
       }
     },
     "/v2/ergebnisliste/ermittlung/{ermittlungsId}/ergebnisse/{ergebnisNummer}/provision": {
@@ -702,6 +741,13 @@
         "description": "Als Parameter wird die ErmittlungsAnfrageId und die Ergebnisnummer benötigt.",
         "operationId": "getProvision",
         "parameters": [
+          {
+            "name": "X-TraceId",
+            "in": "header",
+            "description": "Eine eindeutige technische Id zur Identifikation des Requests.",
+            "required": false,
+            "type": "string"
+          },
           {
             "name": "ergebnisNummer",
             "in": "path",
@@ -783,8 +829,7 @@
               "API"
             ]
           }
-        ],
-        "deprecated": false
+        ]
       }
     },
     "/v2/ergebnisliste/ermittlung/{ermittlungsId}/ergebnisse/{ergebnisNummer}/unterlagen": {
@@ -796,6 +841,13 @@
         "description": "Als Parameter wird die ErmittlungsAnfrageId und die Ergebnisnummer benötigt.",
         "operationId": "getUnterlagen",
         "parameters": [
+          {
+            "name": "X-TraceId",
+            "in": "header",
+            "description": "Eine eindeutige technische Id zur Identifikation des Requests.",
+            "required": false,
+            "type": "string"
+          },
           {
             "name": "ergebnisNummer",
             "in": "path",
@@ -868,8 +920,7 @@
               "API"
             ]
           }
-        ],
-        "deprecated": false
+        ]
       }
     },
     "/v2/ergebnisliste/ermittlung/{ermittlungsId}/ergebnisse/{ergebnisNummer}/zahlungsplaene": {
@@ -881,6 +932,13 @@
         "description": "Als Parameter wird die ErmittlungsAnfrageId und die Ergebnisnummer benötigt.",
         "operationId": "getZahlungsplaene",
         "parameters": [
+          {
+            "name": "X-TraceId",
+            "in": "header",
+            "description": "Eine eindeutige technische Id zur Identifikation des Requests.",
+            "required": false,
+            "type": "string"
+          },
           {
             "name": "ergebnisNummer",
             "in": "path",
@@ -953,8 +1011,7 @@
               "API"
             ]
           }
-        ],
-        "deprecated": false
+        ]
       }
     },
     "/v2/ergebnisliste/ermittlung/{ermittlungsId}/ergebnisse/{ergebnisNummer}/zahlungsplaene/{zahlungsplanIndex}": {
@@ -966,6 +1023,13 @@
         "description": "Als Parameter wird die ErmittlungsAnfrageId, die Ergebnisnummer sowie der Index des Zahlungsplans benötigt.",
         "operationId": "getZahlungsplan",
         "parameters": [
+          {
+            "name": "X-TraceId",
+            "in": "header",
+            "description": "Eine eindeutige technische Id zur Identifikation des Requests.",
+            "required": false,
+            "type": "string"
+          },
           {
             "name": "ergebnisNummer",
             "in": "path",
@@ -1045,8 +1109,7 @@
               "API"
             ]
           }
-        ],
-        "deprecated": false
+        ]
       }
     },
     "/v2/ergebnisliste/ermittlung/{ermittlungsId}/ermittlungsAnfrage": {
@@ -1058,6 +1121,13 @@
         "description": "Als Parameter wird die ErmittlungsId benötigt.",
         "operationId": "getErmittlungsAnfrage",
         "parameters": [
+          {
+            "name": "X-TraceId",
+            "in": "header",
+            "description": "Eine eindeutige technische Id zur Identifikation des Requests.",
+            "required": false,
+            "type": "string"
+          },
           {
             "name": "ermittlungsId",
             "in": "path",
@@ -1122,8 +1192,7 @@
               "API"
             ]
           }
-        ],
-        "deprecated": false
+        ]
       }
     },
     "/v2/ergebnisliste/ermittlung/{ermittlungsId}/ermittlungsAnfrage/erfassteDaten": {
@@ -1135,6 +1204,13 @@
         "description": "Als Parameter wird die ErmittlungsId benötigt.",
         "operationId": "getErfassteDaten",
         "parameters": [
+          {
+            "name": "X-TraceId",
+            "in": "header",
+            "description": "Eine eindeutige technische Id zur Identifikation des Requests.",
+            "required": false,
+            "type": "string"
+          },
           {
             "name": "ermittlungsId",
             "in": "path",
@@ -1199,8 +1275,7 @@
               "API"
             ]
           }
-        ],
-        "deprecated": false
+        ]
       }
     },
     "/version/baufiSmartApi": {
@@ -1212,6 +1287,15 @@
         "operationId": "getBaufiSmartApiVersionUsingGET",
         "produces": [
           "text/plain"
+        ],
+        "parameters": [
+          {
+            "name": "X-TraceId",
+            "in": "header",
+            "description": "Eine eindeutige technische Id zur Identifikation des Requests.",
+            "required": false,
+            "type": "string"
+          }
         ],
         "responses": {
           "200": {
@@ -1269,8 +1353,7 @@
               "API"
             ]
           }
-        ],
-        "deprecated": false
+        ]
       }
     }
   },
@@ -2727,7 +2810,7 @@
         },
         "laufzeitBisJahr": {
           "type": "string",
-          "example": 2088
+          "example": "2088"
         }
       },
       "title": "Erbbaurecht"
@@ -3213,7 +3296,7 @@
         },
         "baujahr": {
           "type": "string",
-          "example": 2016,
+          "example": "2016",
           "description": "Bei verwendungszweck != NEUBAU"
         },
         "bauweise": {
@@ -3910,7 +3993,7 @@
         },
         "modernisierungsJahr": {
           "type": "string",
-          "example": 2016,
+          "example": "2016",
           "description": "Jahr der Modernisierung der Immobilie"
         },
         "raumaufteilung": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3,7 +3,7 @@ swagger: "2.0"
 info:
   description: "Ein Service um eine Ergebnisliste mit Finanzierungsvorschlägen zu\
     \ ermitteln"
-  version: "2.6.1"
+  version: "2.6.2"
   title: "Ergebnislisten API"
   contact:
     name: "Europace AG"
@@ -34,6 +34,11 @@ paths:
       produces:
       - "application/json"
       parameters:
+      - name: "X-TraceId"
+        in: "header"
+        description: "Eine eindeutige technische Id zur Identifikation des Requests."
+        required: false
+        type: "string"
       - name: "alternativen"
         in: "query"
         description: "alternativen"
@@ -103,6 +108,11 @@ paths:
       produces:
       - "application/json"
       parameters:
+      - name: "X-TraceId"
+        in: "header"
+        description: "Eine eindeutige technische Id zur Identifikation des Requests."
+        required: false
+        type: "string"
       - name: "alternativen"
         in: "query"
         description: "alternativen"
@@ -167,6 +177,11 @@ paths:
         \ im Body benötigt"
       operationId: "ermittleErgebnisse"
       parameters:
+      - name: "X-TraceId"
+        in: "header"
+        description: "Eine eindeutige technische Id zur Identifikation des Requests."
+        required: false
+        type: "string"
       - name: "alternativen"
         in: "query"
         description: "alternativen"
@@ -206,10 +221,10 @@ paths:
         required: false
         type: "string"
       responses:
-        200:
-          description: "OK"
-          schema:
-            $ref: "#/definitions/Ermittlung"
+        302:
+          description: "Die Ermittlung wurde erzeugt und ist maximal eine Stunde unter\
+            \ der Url im 'location' Header abrufbar. Beim Abruf der Ermittlung wird\
+            \ der Bearer Token zur Autorisierung erwartet."
         400:
           description: "Bad Request"
           schema:
@@ -253,6 +268,11 @@ paths:
       description: "Als Parameter wird die ErmittlungsId benötigt."
       operationId: "getErmittlung"
       parameters:
+      - name: "X-TraceId"
+        in: "header"
+        description: "Eine eindeutige technische Id zur Identifikation des Requests."
+        required: false
+        type: "string"
       - name: "ermittlungsId"
         in: "path"
         description: "ermittlungsId"
@@ -302,6 +322,11 @@ paths:
       description: "Als Parameter wird die ErmittlungsAnfrageId benötigt."
       operationId: "getErgebnisListe"
       parameters:
+      - name: "X-TraceId"
+        in: "header"
+        description: "Eine eindeutige technische Id zur Identifikation des Requests."
+        required: false
+        type: "string"
       - name: "ermittlungsId"
         in: "path"
         description: "ermittlungsId"
@@ -352,6 +377,11 @@ paths:
         \ benötigt."
       operationId: "getErgebnis"
       parameters:
+      - name: "X-TraceId"
+        in: "header"
+        description: "Eine eindeutige technische Id zur Identifikation des Requests."
+        required: false
+        type: "string"
       - name: "ergebnisNummer"
         in: "path"
         description: "ergebnisNummer"
@@ -408,6 +438,11 @@ paths:
         \ benötigt."
       operationId: "getMeldungen"
       parameters:
+      - name: "X-TraceId"
+        in: "header"
+        description: "Eine eindeutige technische Id zur Identifikation des Requests."
+        required: false
+        type: "string"
       - name: "ergebnisNummer"
         in: "path"
         description: "ergebnisNummer"
@@ -464,6 +499,11 @@ paths:
         \ benötigt."
       operationId: "getProvision"
       parameters:
+      - name: "X-TraceId"
+        in: "header"
+        description: "Eine eindeutige technische Id zur Identifikation des Requests."
+        required: false
+        type: "string"
       - name: "ergebnisNummer"
         in: "path"
         description: "ergebnisNummer"
@@ -527,6 +567,11 @@ paths:
         \ benötigt."
       operationId: "getUnterlagen"
       parameters:
+      - name: "X-TraceId"
+        in: "header"
+        description: "Eine eindeutige technische Id zur Identifikation des Requests."
+        required: false
+        type: "string"
       - name: "ergebnisNummer"
         in: "path"
         description: "ergebnisNummer"
@@ -583,6 +628,11 @@ paths:
         \ benötigt."
       operationId: "getZahlungsplaene"
       parameters:
+      - name: "X-TraceId"
+        in: "header"
+        description: "Eine eindeutige technische Id zur Identifikation des Requests."
+        required: false
+        type: "string"
       - name: "ergebnisNummer"
         in: "path"
         description: "ergebnisNummer"
@@ -639,6 +689,11 @@ paths:
         \ sowie der Index des Zahlungsplans benötigt."
       operationId: "getZahlungsplan"
       parameters:
+      - name: "X-TraceId"
+        in: "header"
+        description: "Eine eindeutige technische Id zur Identifikation des Requests."
+        required: false
+        type: "string"
       - name: "ergebnisNummer"
         in: "path"
         description: "ergebnisNummer"
@@ -699,6 +754,11 @@ paths:
       description: "Als Parameter wird die ErmittlungsId benötigt."
       operationId: "getErmittlungsAnfrage"
       parameters:
+      - name: "X-TraceId"
+        in: "header"
+        description: "Eine eindeutige technische Id zur Identifikation des Requests."
+        required: false
+        type: "string"
       - name: "ermittlungsId"
         in: "path"
         description: "ermittlungsId"
@@ -748,6 +808,11 @@ paths:
       description: "Als Parameter wird die ErmittlungsId benötigt."
       operationId: "getErfassteDaten"
       parameters:
+      - name: "X-TraceId"
+        in: "header"
+        description: "Eine eindeutige technische Id zur Identifikation des Requests."
+        required: false
+        type: "string"
       - name: "ermittlungsId"
         in: "path"
         description: "ermittlungsId"
@@ -797,7 +862,12 @@ paths:
       operationId: "getBaufiSmartApiVersionUsingGET"
       produces:
       - "text/plain"
-      parameters: []
+      parameters:
+      - name: "X-TraceId"
+        in: "header"
+        description: "Eine eindeutige technische Id zur Identifikation des Requests."
+        required: false
+        type: "string"
       responses:
         200:
           description: "OK"


### PR DESCRIPTION
### Motivation
Die  Swagger API-Spezifikation ist korrekt und man kann den Redirect folgen um ermittelte Angebote auszulesen.

### Changes

1. Wir korrigieren die Swagger API-Spezifikation. Von 200er Response auf 302.
2. Wir entfernen den JWT Parameter beim Redirect.
