### PR TITLE
Release 2.7.10 - Update Bauspartarife to version 1.70 and Produktanbieter-IDs to version 1.1107

### DIFF
--- a/angebote-openapi.json
+++ b/angebote-openapi.json
@@ -9,7 +9,7 @@
       "url" : "https://developer.europace.de",
       "email" : "devsupport@europace2.de"
     },
-    "version" : "2.7.9"
+    "version" : "2.7.10"
   },
   "externalDocs" : {
     "url" : "https://docs.api.europace.de/baufinanzierung/angebote/angebote-api/"

--- a/angebote-openapi.yaml
+++ b/angebote-openapi.yaml
@@ -7,7 +7,7 @@ info:
     name: Europace AG
     url: https://developer.europace.de
     email: devsupport@europace2.de
-  version: 2.7.9
+  version: 2.7.10
 externalDocs:
   url: https://docs.api.europace.de/baufinanzierung/angebote/angebote-api/
 servers:

--- a/reference/index.html
+++ b/reference/index.html
@@ -14,170 +14,170 @@
       article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section {
         display: block
       }
-      
+
       audio, video {
         display: inline-block
       }
-      
+
       audio:not([controls]) {
         display: none;
         height: 0
       }
-      
+
       html {
         font-family: sans-serif;
         -ms-text-size-adjust: 100%;
         -webkit-text-size-adjust: 100%
       }
-      
+
       a {
         background: none
       }
-      
+
       a:focus {
         outline: thin dotted
       }
-      
+
       a:active, a:hover {
         outline: 0
       }
-      
+
       h1 {
         font-size: 2em;
         margin: .67em 0
       }
-      
+
       abbr[title] {
         border-bottom: 1px dotted
       }
-      
+
       b, strong {
         font-weight: bold
       }
-      
+
       dfn {
         font-style: italic
       }
-      
+
       hr {
         -moz-box-sizing: content-box;
         box-sizing: content-box;
         height: 0
       }
-      
+
       mark {
         background: #ff0;
         color: #000
       }
-      
+
       code, kbd, pre, samp {
         font-family: monospace;
         font-size: 1em
       }
-      
+
       pre {
         white-space: pre-wrap
       }
-      
+
       q {
         quotes: "\201C" "\201D" "\2018" "\2019"
       }
-      
+
       small {
         font-size: 80%
       }
-      
+
       sub, sup {
         font-size: 75%;
         line-height: 0;
         position: relative;
         vertical-align: baseline
       }
-      
+
       sup {
         top: -.5em
       }
-      
+
       sub {
         bottom: -.25em
       }
-      
+
       img {
         border: 0
       }
-      
+
       svg:not(:root) {
         overflow: hidden
       }
-      
+
       figure {
         margin: 0
       }
-      
+
       fieldset {
         border: 1px solid silver;
         margin: 0 2px;
         padding: .35em .625em .75em
       }
-      
+
       legend {
         border: 0;
         padding: 0
       }
-      
+
       button, input, select, textarea {
         font-family: inherit;
         font-size: 100%;
         margin: 0
       }
-      
+
       button, input {
         line-height: normal
       }
-      
+
       button, select {
         text-transform: none
       }
-      
+
       button, html input[type="button"], input[type="reset"], input[type="submit"] {
         -webkit-appearance: button;
         cursor: pointer
       }
-      
+
       button[disabled], html input[disabled] {
         cursor: default
       }
-      
+
       input[type="checkbox"], input[type="radio"] {
         box-sizing: border-box;
         padding: 0
       }
-      
+
       button::-moz-focus-inner, input::-moz-focus-inner {
         border: 0;
         padding: 0
       }
-      
+
       textarea {
         overflow: auto;
         vertical-align: top
       }
-      
+
       table {
         border-collapse: collapse;
         border-spacing: 0
       }
-      
+
       *, *::before, *::after {
         -moz-box-sizing: border-box;
         -webkit-box-sizing: border-box;
         box-sizing: border-box
       }
-      
+
       html, body {
         font-size: 100%
       }
-      
+
       body {
         background: #fff;
         color: rgba(0, 0, 0, .8);
@@ -193,75 +193,75 @@
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased
       }
-      
+
       a:hover {
         cursor: pointer
       }
-      
+
       img, object, embed {
         max-width: 100%;
         height: auto
       }
-      
+
       object, embed {
         height: 100%
       }
-      
+
       img {
         -ms-interpolation-mode: bicubic
       }
-      
+
       .left {
         float: left !important
       }
-      
+
       .right {
         float: right !important
       }
-      
+
       .text-left {
         text-align: left !important
       }
-      
+
       .text-right {
         text-align: right !important
       }
-      
+
       .text-center {
         text-align: center !important
       }
-      
+
       .text-justify {
         text-align: justify !important
       }
-      
+
       .hide {
         display: none
       }
-      
+
       img, object, svg {
         display: inline-block;
         vertical-align: middle
       }
-      
+
       textarea {
         height: auto;
         min-height: 50px
       }
-      
+
       select {
         width: 100%
       }
-      
+
       .center {
         margin-left: auto;
         margin-right: auto
       }
-      
+
       .stretch {
         width: 100%
       }
-      
+
       .subheader, .admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title {
         line-height: 1.45;
         color: #7a2518;
@@ -269,27 +269,27 @@
         margin-top: 0;
         margin-bottom: .25em
       }
-      
+
       div, dl, dt, dd, ul, ol, li, h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6, pre, form, p, blockquote, th, td {
         margin: 0;
         padding: 0;
         direction: ltr
       }
-      
+
       a {
         color: #2156a5;
         text-decoration: underline;
         line-height: inherit
       }
-      
+
       a:hover, a:focus {
         color: #1d4b8f
       }
-      
+
       a img {
         border: 0
       }
-      
+
       p {
         font-family: inherit;
         font-weight: 400;
@@ -298,13 +298,13 @@
         margin-bottom: 1.25em;
         text-rendering: optimizeLegibility
       }
-      
+
       p aside {
         font-size: .875em;
         line-height: 1.35;
         font-style: italic
       }
-      
+
       h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 {
         font-family: "Open Sans", "DejaVu Sans", sans-serif;
         font-weight: 300;
@@ -315,33 +315,33 @@
         margin-bottom: .5em;
         line-height: 1.0125em
       }
-      
+
       h1 small, h2 small, h3 small, #toctitle small, .sidebarblock > .content > .title small, h4 small, h5 small, h6 small {
         font-size: 60%;
         color: #e99b8f;
         line-height: 0
       }
-      
+
       h1 {
         font-size: 2.125em
       }
-      
+
       h2 {
         font-size: 1.6875em
       }
-      
+
       h3, #toctitle, .sidebarblock > .content > .title {
         font-size: 1.375em
       }
-      
+
       h4, h5 {
         font-size: 1.125em
       }
-      
+
       h6 {
         font-size: 1em
       }
-      
+
       hr {
         border: solid #dddddf;
         border-width: 1px 0 0;
@@ -349,28 +349,28 @@
         margin: 1.25em 0 1.1875em;
         height: 0
       }
-      
+
       em, i {
         font-style: italic;
         line-height: inherit
       }
-      
+
       strong, b {
         font-weight: bold;
         line-height: inherit
       }
-      
+
       small {
         font-size: 60%;
         line-height: inherit
       }
-      
+
       code {
         font-family: "Droid Sans Mono", "DejaVu Sans Mono", monospace;
         font-weight: 400;
         color: rgba(0, 0, 0, .9)
       }
-      
+
       ul, ol, dl {
         font-size: 1em;
         line-height: 1.6;
@@ -378,47 +378,47 @@
         list-style-position: outside;
         font-family: inherit
       }
-      
+
       ul, ol {
         margin-left: 1.5em
       }
-      
+
       ul li ul, ul li ol {
         margin-left: 1.25em;
         margin-bottom: 0;
         font-size: 1em
       }
-      
+
       ul.square li ul, ul.circle li ul, ul.disc li ul {
         list-style: inherit
       }
-      
+
       ul.square {
         list-style-type: square
       }
-      
+
       ul.circle {
         list-style-type: circle
       }
-      
+
       ul.disc {
         list-style-type: disc
       }
-      
+
       ol li ul, ol li ol {
         margin-left: 1.25em;
         margin-bottom: 0
       }
-      
+
       dl dt {
         margin-bottom: .3125em;
         font-weight: bold
       }
-      
+
       dl dd {
         margin-bottom: 1.25em
       }
-      
+
       abbr, acronym {
         text-transform: uppercase;
         font-size: 90%;
@@ -426,108 +426,108 @@
         border-bottom: 1px dotted #ddd;
         cursor: help
       }
-      
+
       abbr {
         text-transform: none
       }
-      
+
       blockquote {
         margin: 0 0 1.25em;
         padding: .5625em 1.25em 0 1.1875em;
         border-left: 1px solid #ddd
       }
-      
+
       blockquote cite {
         display: block;
         font-size: .9375em;
         color: rgba(0, 0, 0, .6)
       }
-      
+
       blockquote cite::before {
         content: "\2014 \0020"
       }
-      
+
       blockquote cite a, blockquote cite a:visited {
         color: rgba(0, 0, 0, .6)
       }
-      
+
       blockquote, blockquote p {
         line-height: 1.6;
         color: rgba(0, 0, 0, .85)
       }
-      
+
       @media screen and (min-width: 768px) {
         h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 {
           line-height: 1.2
         }
-      
+
         h1 {
           font-size: 2.75em
         }
-      
+
         h2 {
           font-size: 2.3125em
         }
-      
+
         h3, #toctitle, .sidebarblock > .content > .title {
           font-size: 1.6875em
         }
-      
+
         h4 {
           font-size: 1.4375em
         }
       }
-      
+
       table {
         background: #fff;
         margin-bottom: 1.25em;
         border: solid 1px #dedede
       }
-      
+
       table thead, table tfoot {
         background: #f7f8f7
       }
-      
+
       table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td {
         padding: .5em .625em .625em;
         font-size: inherit;
         color: rgba(0, 0, 0, .8);
         text-align: left
       }
-      
+
       table tr th, table tr td {
         padding: .5625em .625em;
         font-size: inherit;
         color: rgba(0, 0, 0, .8)
       }
-      
+
       table tr.even, table tr.alt {
         background: #f8f8f7
       }
-      
+
       table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td {
         display: table-cell;
         line-height: 1.6
       }
-      
+
       h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 {
         line-height: 1.2;
         word-spacing: -.05em
       }
-      
+
       h1 strong, h2 strong, h3 strong, #toctitle strong, .sidebarblock > .content > .title strong, h4 strong, h5 strong, h6 strong {
         font-weight: 400
       }
-      
+
       .clearfix::before, .clearfix::after, .float-group::before, .float-group::after {
         content: " ";
         display: table
       }
-      
+
       .clearfix::after, .float-group::after {
         clear: both
       }
-      
+
       :not(pre):not([class^=L]) > code {
         font-size: .9375em;
         font-style: normal !important;
@@ -541,49 +541,49 @@
         text-rendering: optimizeSpeed;
         word-wrap: break-word
       }
-      
+
       :not(pre) > code.nobreak {
         word-wrap: normal
       }
-      
+
       :not(pre) > code.nowrap {
         white-space: nowrap
       }
-      
+
       pre {
         color: rgba(0, 0, 0, .9);
         font-family: "Droid Sans Mono", "DejaVu Sans Mono", monospace;
         line-height: 1.45;
         text-rendering: optimizeSpeed
       }
-      
+
       pre code, pre pre {
         color: inherit;
         font-size: inherit;
         line-height: inherit
       }
-      
+
       pre > code {
         display: block
       }
-      
+
       pre.nowrap, pre.nowrap pre {
         white-space: pre;
         word-wrap: normal
       }
-      
+
       em em {
         font-style: normal
       }
-      
+
       strong strong {
         font-weight: 400
       }
-      
+
       .keyseq {
         color: rgba(51, 51, 51, .8)
       }
-      
+
       kbd {
         font-family: "Droid Sans Mono", "DejaVu Sans Mono", monospace;
         display: inline-block;
@@ -603,58 +603,58 @@
         top: -.1em;
         white-space: nowrap
       }
-      
+
       .keyseq kbd:first-child {
         margin-left: 0
       }
-      
+
       .keyseq kbd:last-child {
         margin-right: 0
       }
-      
+
       .menuseq, .menuref {
         color: #000
       }
-      
+
       .menuseq b:not(.caret), .menuref {
         font-weight: inherit
       }
-      
+
       .menuseq {
         word-spacing: -.02em
       }
-      
+
       .menuseq b.caret {
         font-size: 1.25em;
         line-height: .8
       }
-      
+
       .menuseq i.caret {
         font-weight: bold;
         text-align: center;
         width: .45em
       }
-      
+
       b.button::before, b.button::after {
         position: relative;
         top: -1px;
         font-weight: 400
       }
-      
+
       b.button::before {
         content: "[";
         padding: 0 3px 0 2px
       }
-      
+
       b.button::after {
         content: "]";
         padding: 0 2px 0 3px
       }
-      
+
       p a > code:hover {
         color: rgba(0, 0, 0, .9)
       }
-      
+
       #header, #content, #footnotes, #footer {
         width: 100%;
         margin-left: auto;
@@ -667,40 +667,40 @@
         padding-left: .9375em;
         padding-right: .9375em
       }
-      
+
       #header::before, #header::after, #content::before, #content::after, #footnotes::before, #footnotes::after, #footer::before, #footer::after {
         content: " ";
         display: table
       }
-      
+
       #header::after, #content::after, #footnotes::after, #footer::after {
         clear: both
       }
-      
+
       #content {
         margin-top: 1.25em
       }
-      
+
       #content::before {
         content: none
       }
-      
+
       #header > h1:first-child {
         color: rgba(0, 0, 0, .85);
         margin-top: 2.25rem;
         margin-bottom: 0
       }
-      
+
       #header > h1:first-child + #toc {
         margin-top: 8px;
         border-top: 1px solid #dddddf
       }
-      
+
       #header > h1:only-child, body.toc2 #header > h1:nth-last-child(2) {
         border-bottom: 1px solid #dddddf;
         padding-bottom: 8px
       }
-      
+
       #header .details {
         border-bottom: 1px solid #dddddf;
         line-height: 1.45;
@@ -715,40 +715,40 @@
         -webkit-flex-flow: row wrap;
         flex-flow: row wrap
       }
-      
+
       #header .details span:first-child {
         margin-left: -.125em
       }
-      
+
       #header .details span.email a {
         color: rgba(0, 0, 0, .85)
       }
-      
+
       #header .details br {
         display: none
       }
-      
+
       #header .details br + span::before {
         content: "\00a0\2013\00a0"
       }
-      
+
       #header .details br + span.author::before {
         content: "\00a0\22c5\00a0";
         color: rgba(0, 0, 0, .85)
       }
-      
+
       #header .details br + span#revremark::before {
         content: "\00a0|\00a0"
       }
-      
+
       #header #revnumber {
         text-transform: capitalize
       }
-      
+
       #header #revnumber::after {
         content: "\00a0"
       }
-      
+
       #content > h1:first-child:not([class]) {
         color: rgba(0, 0, 0, .85);
         border-bottom: 1px solid #dddddf;
@@ -757,57 +757,57 @@
         padding-top: 1rem;
         margin-bottom: 1.25rem
       }
-      
+
       #toc {
         border-bottom: 1px solid #e7e7e9;
         padding-bottom: .5em
       }
-      
+
       #toc > ul {
         margin-left: .125em
       }
-      
+
       #toc ul.sectlevel0 > li > a {
         font-style: italic
       }
-      
+
       #toc ul.sectlevel0 ul.sectlevel1 {
         margin: .5em 0
       }
-      
+
       #toc ul {
         font-family: "Open Sans", "DejaVu Sans", sans-serif;
         list-style-type: none
       }
-      
+
       #toc li {
         line-height: 1.3334;
         margin-top: .3334em
       }
-      
+
       #toc a {
         text-decoration: none
       }
-      
+
       #toc a:active {
         text-decoration: underline
       }
-      
+
       #toctitle {
         color: #7a2518;
         font-size: 1.2em
       }
-      
+
       @media screen and (min-width: 768px) {
         #toctitle {
           font-size: 1.375em
         }
-      
+
         body.toc2 {
           padding-left: 15em;
           padding-right: 0
         }
-      
+
         #toc.toc2 {
           margin-top: 0 !important;
           background: #f8f8f7;
@@ -823,34 +823,34 @@
           height: 100%;
           overflow: auto
         }
-      
+
         #toc.toc2 #toctitle {
           margin-top: 0;
           margin-bottom: .8rem;
           font-size: 1.2em
         }
-      
+
         #toc.toc2 > ul {
           font-size: .9em;
           margin-bottom: 0
         }
-      
+
         #toc.toc2 ul ul {
           margin-left: 0;
           padding-left: 1em
         }
-      
+
         #toc.toc2 ul.sectlevel0 ul.sectlevel1 {
           padding-left: 0;
           margin-top: .5em;
           margin-bottom: .5em
         }
-      
+
         body.toc2.toc-right {
           padding-left: 0;
           padding-right: 15em
         }
-      
+
         body.toc2.toc-right #toc.toc2 {
           border-right-width: 0;
           border-left: 1px solid #e7e7e9;
@@ -858,35 +858,35 @@
           right: 0
         }
       }
-      
+
       @media screen and (min-width: 1280px) {
         body.toc2 {
           padding-left: 20em;
           padding-right: 0
         }
-      
+
         #toc.toc2 {
           width: 20em
         }
-      
+
         #toc.toc2 #toctitle {
           font-size: 1.375em
         }
-      
+
         #toc.toc2 > ul {
           font-size: .95em
         }
-      
+
         #toc.toc2 ul ul {
           padding-left: 1.25em
         }
-      
+
         body.toc2.toc-right {
           padding-left: 0;
           padding-right: 20em
         }
       }
-      
+
       #content #toc {
         border-style: solid;
         border-width: 1px;
@@ -897,52 +897,52 @@
         -webkit-border-radius: 4px;
         border-radius: 4px
       }
-      
+
       #content #toc > :first-child {
         margin-top: 0
       }
-      
+
       #content #toc > :last-child {
         margin-bottom: 0
       }
-      
+
       #footer {
         max-width: 100%;
         background: rgba(0, 0, 0, .8);
         padding: 1.25em
       }
-      
+
       #footer-text {
         color: rgba(255, 255, 255, .8);
         line-height: 1.44
       }
-      
+
       #content {
         margin-bottom: .625em
       }
-      
+
       .sect1 {
         padding-bottom: .625em
       }
-      
+
       @media screen and (min-width: 768px) {
         #content {
           margin-bottom: 1.25em
         }
-      
+
         .sect1 {
           padding-bottom: 1.25em
         }
       }
-      
+
       .sect1:last-child {
         padding-bottom: 0
       }
-      
+
       .sect1 + .sect1 {
         border-top: 1px solid #e7e7e9
       }
-      
+
       #content h1 > a.anchor, h2 > a.anchor, h3 > a.anchor, #toctitle > a.anchor, .sidebarblock > .content > .title > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor {
         position: absolute;
         z-index: 1001;
@@ -954,38 +954,38 @@
         text-align: center;
         font-weight: 400
       }
-      
+
       #content h1 > a.anchor::before, h2 > a.anchor::before, h3 > a.anchor::before, #toctitle > a.anchor::before, .sidebarblock > .content > .title > a.anchor::before, h4 > a.anchor::before, h5 > a.anchor::before, h6 > a.anchor::before {
         content: "\00A7";
         font-size: .85em;
         display: block;
         padding-top: .1em
       }
-      
+
       #content h1:hover > a.anchor, #content h1 > a.anchor:hover, h2:hover > a.anchor, h2 > a.anchor:hover, h3:hover > a.anchor, #toctitle:hover > a.anchor, .sidebarblock > .content > .title:hover > a.anchor, h3 > a.anchor:hover, #toctitle > a.anchor:hover, .sidebarblock > .content > .title > a.anchor:hover, h4:hover > a.anchor, h4 > a.anchor:hover, h5:hover > a.anchor, h5 > a.anchor:hover, h6:hover > a.anchor, h6 > a.anchor:hover {
         visibility: visible
       }
-      
+
       #content h1 > a.link, h2 > a.link, h3 > a.link, #toctitle > a.link, .sidebarblock > .content > .title > a.link, h4 > a.link, h5 > a.link, h6 > a.link {
         color: #ba3925;
         text-decoration: none
       }
-      
+
       #content h1 > a.link:hover, h2 > a.link:hover, h3 > a.link:hover, #toctitle > a.link:hover, .sidebarblock > .content > .title > a.link:hover, h4 > a.link:hover, h5 > a.link:hover, h6 > a.link:hover {
         color: #a53221
       }
-      
+
       details, .audioblock, .imageblock, .literalblock, .listingblock, .stemblock, .videoblock {
         margin-bottom: 1.25em
       }
-      
+
       details > summary:first-of-type {
         cursor: pointer;
         display: list-item;
         outline: none;
         margin-bottom: .75em
       }
-      
+
       .admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title {
         text-rendering: optimizeLegibility;
         text-align: left;
@@ -993,55 +993,55 @@
         font-size: 1rem;
         font-style: italic
       }
-      
+
       table.tableblock.fit-content > caption.title {
         white-space: nowrap;
         width: 0
       }
-      
+
       .paragraph.lead > p, #preamble > .sectionbody > [class="paragraph"]:first-of-type p {
         font-size: 1.21875em;
         line-height: 1.6;
         color: rgba(0, 0, 0, .85)
       }
-      
+
       table.tableblock #preamble > .sectionbody > [class="paragraph"]:first-of-type p {
         font-size: inherit
       }
-      
+
       .admonitionblock > table {
         border-collapse: separate;
         border: 0;
         background: none;
         width: 100%
       }
-      
+
       .admonitionblock > table td.icon {
         text-align: center;
         width: 80px
       }
-      
+
       .admonitionblock > table td.icon img {
         max-width: none
       }
-      
+
       .admonitionblock > table td.icon .title {
         font-weight: bold;
         font-family: "Open Sans", "DejaVu Sans", sans-serif;
         text-transform: uppercase
       }
-      
+
       .admonitionblock > table td.content {
         padding-left: 1.125em;
         padding-right: 1.25em;
         border-left: 1px solid #dddddf;
         color: rgba(0, 0, 0, .6)
       }
-      
+
       .admonitionblock > table td.content > :last-child > :last-child {
         margin-bottom: 0
       }
-      
+
       .exampleblock > .content {
         border-style: solid;
         border-width: 1px;
@@ -1052,15 +1052,15 @@
         -webkit-border-radius: 4px;
         border-radius: 4px
       }
-      
+
       .exampleblock > .content > :first-child {
         margin-top: 0
       }
-      
+
       .exampleblock > .content > :last-child {
         margin-bottom: 0
       }
-      
+
       .sidebarblock {
         border-style: solid;
         border-width: 1px;
@@ -1071,25 +1071,25 @@
         -webkit-border-radius: 4px;
         border-radius: 4px
       }
-      
+
       .sidebarblock > :first-child {
         margin-top: 0
       }
-      
+
       .sidebarblock > :last-child {
         margin-bottom: 0
       }
-      
+
       .sidebarblock > .content > .title {
         color: #7a2518;
         margin-top: 0;
         text-align: center
       }
-      
+
       .exampleblock > .content > :last-child > :last-child, .exampleblock > .content .olist > ol > li:last-child > :last-child, .exampleblock > .content .ulist > ul > li:last-child > :last-child, .exampleblock > .content .qlist > ol > li:last-child > :last-child, .sidebarblock > .content > :last-child > :last-child, .sidebarblock > .content .olist > ol > li:last-child > :last-child, .sidebarblock > .content .ulist > ul > li:last-child > :last-child, .sidebarblock > .content .qlist > ol > li:last-child > :last-child {
         margin-bottom: 0
       }
-      
+
       .literalblock pre, .listingblock > .content > pre {
         -webkit-border-radius: 4px;
         border-radius: 4px;
@@ -1098,32 +1098,32 @@
         padding: 1em;
         font-size: .8125em
       }
-      
+
       @media screen and (min-width: 768px) {
         .literalblock pre, .listingblock > .content > pre {
           font-size: .90625em
         }
       }
-      
+
       @media screen and (min-width: 1280px) {
         .literalblock pre, .listingblock > .content > pre {
           font-size: 1em
         }
       }
-      
+
       .literalblock pre, .listingblock > .content > pre:not(.highlight), .listingblock > .content > pre[class="highlight"], .listingblock > .content > pre[class^="highlight "] {
         background: #f7f7f8
       }
-      
+
       .literalblock.output pre {
         color: #f7f7f8;
         background: rgba(0, 0, 0, .9)
       }
-      
+
       .listingblock > .content {
         position: relative
       }
-      
+
       .listingblock code[data-lang]::before {
         display: none;
         content: attr(data-lang);
@@ -1136,66 +1136,66 @@
         color: inherit;
         opacity: .5
       }
-      
+
       .listingblock:hover code[data-lang]::before {
         display: block
       }
-      
+
       .listingblock.terminal pre .command::before {
         content: attr(data-prompt);
         padding-right: .5em;
         color: inherit;
         opacity: .5
       }
-      
+
       .listingblock.terminal pre .command:not([data-prompt])::before {
         content: "$"
       }
-      
+
       .listingblock pre.highlightjs {
         padding: 0
       }
-      
+
       .listingblock pre.highlightjs > code {
         padding: 1em;
         -webkit-border-radius: 4px;
         border-radius: 4px
       }
-      
+
       .listingblock pre.prettyprint {
         border-width: 0
       }
-      
+
       .prettyprint {
         background: #f7f7f8
       }
-      
+
       pre.prettyprint .linenums {
         line-height: 1.45;
         margin-left: 2em
       }
-      
+
       pre.prettyprint li {
         background: none;
         list-style-type: inherit;
         padding-left: 0
       }
-      
+
       pre.prettyprint li code[data-lang]::before {
         opacity: 1
       }
-      
+
       pre.prettyprint li:not(:first-child) code[data-lang]::before {
         display: none
       }
-      
+
       table.linenotable {
         border-collapse: separate;
         border: 0;
         margin-bottom: 0;
         background: none
       }
-      
+
       table.linenotable td[class] {
         color: inherit;
         vertical-align: top;
@@ -1203,39 +1203,39 @@
         line-height: inherit;
         white-space: normal
       }
-      
+
       table.linenotable td.code {
         padding-left: .75em
       }
-      
+
       table.linenotable td.linenos {
         border-right: 1px solid currentColor;
         opacity: .35;
         padding-right: .5em
       }
-      
+
       pre.pygments .lineno {
         border-right: 1px solid currentColor;
         opacity: .35;
         display: inline-block;
         margin-right: .75em
       }
-      
+
       pre.pygments .lineno::before {
         content: "";
         margin-right: -.125em
       }
-      
+
       .quoteblock {
         margin: 0 1em 1.25em 1.5em;
         display: table
       }
-      
+
       .quoteblock:not(.excerpt) > .title {
         margin-left: -1.5em;
         margin-bottom: .75em
       }
-      
+
       .quoteblock blockquote, .quoteblock p {
         color: rgba(0, 0, 0, .85);
         font-size: 1.15rem;
@@ -1245,13 +1245,13 @@
         font-style: italic;
         text-align: justify
       }
-      
+
       .quoteblock blockquote {
         margin: 0;
         padding: 0;
         border: 0
       }
-      
+
       .quoteblock blockquote::before {
         content: "\201c";
         float: left;
@@ -1262,21 +1262,21 @@
         color: #7a2518;
         text-shadow: 0 1px 2px rgba(0, 0, 0, .1)
       }
-      
+
       .quoteblock blockquote > .paragraph:last-child p {
         margin-bottom: 0
       }
-      
+
       .quoteblock .attribution {
         margin-top: .75em;
         margin-right: .5ex;
         text-align: right
       }
-      
+
       .verseblock {
         margin: 0 1em 1.25em
       }
-      
+
       .verseblock pre {
         font-family: "Open Sans", "DejaVu Sans", sans;
         font-size: 1.15rem;
@@ -1284,232 +1284,232 @@
         font-weight: 300;
         text-rendering: optimizeLegibility
       }
-      
+
       .verseblock pre strong {
         font-weight: 400
       }
-      
+
       .verseblock .attribution {
         margin-top: 1.25rem;
         margin-left: .5ex
       }
-      
+
       .quoteblock .attribution, .verseblock .attribution {
         font-size: .9375em;
         line-height: 1.45;
         font-style: italic
       }
-      
+
       .quoteblock .attribution br, .verseblock .attribution br {
         display: none
       }
-      
+
       .quoteblock .attribution cite, .verseblock .attribution cite {
         display: block;
         letter-spacing: -.025em;
         color: rgba(0, 0, 0, .6)
       }
-      
+
       .quoteblock.abstract blockquote::before, .quoteblock.excerpt blockquote::before, .quoteblock .quoteblock blockquote::before {
         display: none
       }
-      
+
       .quoteblock.abstract blockquote, .quoteblock.abstract p, .quoteblock.excerpt blockquote, .quoteblock.excerpt p, .quoteblock .quoteblock blockquote, .quoteblock .quoteblock p {
         line-height: 1.6;
         word-spacing: 0
       }
-      
+
       .quoteblock.abstract {
         margin: 0 1em 1.25em;
         display: block
       }
-      
+
       .quoteblock.abstract > .title {
         margin: 0 0 .375em;
         font-size: 1.15em;
         text-align: center
       }
-      
+
       .quoteblock.excerpt > blockquote, .quoteblock .quoteblock {
         padding: 0 0 .25em 1em;
         border-left: .25em solid #dddddf
       }
-      
+
       .quoteblock.excerpt, .quoteblock .quoteblock {
         margin-left: 0
       }
-      
+
       .quoteblock.excerpt blockquote, .quoteblock.excerpt p, .quoteblock .quoteblock blockquote, .quoteblock .quoteblock p {
         color: inherit;
         font-size: 1.0625rem
       }
-      
+
       .quoteblock.excerpt .attribution, .quoteblock .quoteblock .attribution {
         color: inherit;
         text-align: left;
         margin-right: 0
       }
-      
+
       table.tableblock {
         max-width: 100%;
         border-collapse: separate
       }
-      
+
       p.tableblock:last-child {
         margin-bottom: 0
       }
-      
+
       td.tableblock > .content > :last-child {
         margin-bottom: -1.25em
       }
-      
+
       td.tableblock > .content > :last-child.sidebarblock {
         margin-bottom: 0
       }
-      
+
       table.tableblock, th.tableblock, td.tableblock {
         border: 0 solid #dedede
       }
-      
+
       table.grid-all > thead > tr > .tableblock, table.grid-all > tbody > tr > .tableblock {
         border-width: 0 1px 1px 0
       }
-      
+
       table.grid-all > tfoot > tr > .tableblock {
         border-width: 1px 1px 0 0
       }
-      
+
       table.grid-cols > * > tr > .tableblock {
         border-width: 0 1px 0 0
       }
-      
+
       table.grid-rows > thead > tr > .tableblock, table.grid-rows > tbody > tr > .tableblock {
         border-width: 0 0 1px
       }
-      
+
       table.grid-rows > tfoot > tr > .tableblock {
         border-width: 1px 0 0
       }
-      
+
       table.grid-all > * > tr > .tableblock:last-child, table.grid-cols > * > tr > .tableblock:last-child {
         border-right-width: 0
       }
-      
+
       table.grid-all > tbody > tr:last-child > .tableblock, table.grid-all > thead:last-child > tr > .tableblock, table.grid-rows > tbody > tr:last-child > .tableblock, table.grid-rows > thead:last-child > tr > .tableblock {
         border-bottom-width: 0
       }
-      
+
       table.frame-all {
         border-width: 1px
       }
-      
+
       table.frame-sides {
         border-width: 0 1px
       }
-      
+
       table.frame-topbot, table.frame-ends {
         border-width: 1px 0
       }
-      
+
       table.stripes-all tr, table.stripes-odd tr:nth-of-type(odd), table.stripes-even tr:nth-of-type(even), table.stripes-hover tr:hover {
         background: #f8f8f7
       }
-      
+
       th.halign-left, td.halign-left {
         text-align: left
       }
-      
+
       th.halign-right, td.halign-right {
         text-align: right
       }
-      
+
       th.halign-center, td.halign-center {
         text-align: center
       }
-      
+
       th.valign-top, td.valign-top {
         vertical-align: top
       }
-      
+
       th.valign-bottom, td.valign-bottom {
         vertical-align: bottom
       }
-      
+
       th.valign-middle, td.valign-middle {
         vertical-align: middle
       }
-      
+
       table thead th, table tfoot th {
         font-weight: bold
       }
-      
+
       tbody tr th {
         display: table-cell;
         line-height: 1.6;
         background: #f7f8f7
       }
-      
+
       tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p {
         color: rgba(0, 0, 0, .8);
         font-weight: bold
       }
-      
+
       p.tableblock > code:only-child {
         background: none;
         padding: 0
       }
-      
+
       p.tableblock {
         font-size: 1em
       }
-      
+
       ol {
         margin-left: 1.75em
       }
-      
+
       ul li ol {
         margin-left: 1.5em
       }
-      
+
       dl dd {
         margin-left: 1.125em
       }
-      
+
       dl dd:last-child, dl dd:last-child > :last-child {
         margin-bottom: 0
       }
-      
+
       ol > li p, ul > li p, ul dd, ol dd, .olist .olist, .ulist .ulist, .ulist .olist, .olist .ulist {
         margin-bottom: .625em
       }
-      
+
       ul.checklist, ul.none, ol.none, ul.no-bullet, ol.no-bullet, ol.unnumbered, ul.unstyled, ol.unstyled {
         list-style-type: none
       }
-      
+
       ul.no-bullet, ol.no-bullet, ol.unnumbered {
         margin-left: .625em
       }
-      
+
       ul.unstyled, ol.unstyled {
         margin-left: 0
       }
-      
+
       ul.checklist {
         margin-left: .625em
       }
-      
+
       ul.checklist li > p:first-child > .fa-square-o:first-child, ul.checklist li > p:first-child > .fa-check-square-o:first-child {
         width: 1.25em;
         font-size: .8em;
         position: relative;
         bottom: .125em
       }
-      
+
       ul.checklist li > p:first-child > input[type="checkbox"]:first-child {
         margin-right: .25em
       }
-      
+
       ul.inline {
         display: -ms-flexbox;
         display: -webkit-box;
@@ -1520,81 +1520,81 @@
         list-style: none;
         margin: 0 0 .625em -1.25em
       }
-      
+
       ul.inline > li {
         margin-left: 1.25em
       }
-      
+
       .unstyled dl dt {
         font-weight: 400;
         font-style: normal
       }
-      
+
       ol.arabic {
         list-style-type: decimal
       }
-      
+
       ol.decimal {
         list-style-type: decimal-leading-zero
       }
-      
+
       ol.loweralpha {
         list-style-type: lower-alpha
       }
-      
+
       ol.upperalpha {
         list-style-type: upper-alpha
       }
-      
+
       ol.lowerroman {
         list-style-type: lower-roman
       }
-      
+
       ol.upperroman {
         list-style-type: upper-roman
       }
-      
+
       ol.lowergreek {
         list-style-type: lower-greek
       }
-      
+
       .hdlist > table, .colist > table {
         border: 0;
         background: none
       }
-      
+
       .hdlist > table > tbody > tr, .colist > table > tbody > tr {
         background: none
       }
-      
+
       td.hdlist1, td.hdlist2 {
         vertical-align: top;
         padding: 0 .625em
       }
-      
+
       td.hdlist1 {
         font-weight: bold;
         padding-bottom: 1.25em
       }
-      
+
       .literalblock + .colist, .listingblock + .colist {
         margin-top: -.5em
       }
-      
+
       .colist td:not([class]):first-child {
         padding: .4em .75em 0;
         line-height: 1;
         vertical-align: top
       }
-      
+
       .colist td:not([class]):first-child img {
         max-width: none
       }
-      
+
       .colist td:not([class]):last-child {
         padding: .25em 0
       }
-      
+
       .thumb, .th {
         line-height: 0;
         display: inline-block;
@@ -1602,78 +1602,78 @@
         -webkit-box-shadow: 0 0 0 1px #ddd;
         box-shadow: 0 0 0 1px #ddd
       }
-      
+
       .imageblock.left {
         margin: .25em .625em 1.25em 0
       }
-      
+
       .imageblock.right {
         margin: .25em 0 1.25em .625em
       }
-      
+
       .imageblock > .title {
         margin-bottom: 0
       }
-      
+
       .imageblock.thumb, .imageblock.th {
         border-width: 6px
       }
-      
+
       .imageblock.thumb > .title, .imageblock.th > .title {
         padding: 0 .125em
       }
-      
+
       .image.left, .image.right {
         margin-top: .25em;
         margin-bottom: .25em;
         display: inline-block;
         line-height: 0
       }
-      
+
       .image.left {
         margin-right: .625em
       }
-      
+
       .image.right {
         margin-left: .625em
       }
-      
+
       a.image {
         text-decoration: none;
         display: inline-block
       }
-      
+
       a.image object {
         pointer-events: none
       }
-      
+
       sup.footnote, sup.footnoteref {
         font-size: .875em;
         position: static;
         vertical-align: super
       }
-      
+
       sup.footnote a, sup.footnoteref a {
         text-decoration: none
       }
-      
+
       sup.footnote a:active, sup.footnoteref a:active {
         text-decoration: underline
       }
-      
+
       #footnotes {
         padding-top: .75em;
         padding-bottom: .75em;
         margin-bottom: .625em
       }
-      
+
       #footnotes hr {
         width: 20%;
         min-width: 6.25em;
         margin: -.25em 0 .75em;
         border-width: 1px 0 0
       }
-      
+
       #footnotes .footnote {
         padding: 0 .375em 0 .225em;
         line-height: 1.3334;
@@ -1681,226 +1681,226 @@
         margin-left: 1.2em;
         margin-bottom: .2em
       }
-      
+
       #footnotes .footnote a:first-of-type {
         font-weight: bold;
         text-decoration: none;
         margin-left: -1.05em
       }
-      
+
       #footnotes .footnote:last-of-type {
         margin-bottom: 0
       }
-      
+
       #content #footnotes {
         margin-top: -.625em;
         margin-bottom: 0;
         padding: .75em 0
       }
-      
+
       .gist .file-data > table {
         border: 0;
         background: #fff;
         width: 100%;
         margin-bottom: 0
       }
-      
+
       .gist .file-data > table td.line-data {
         width: 99%
       }
-      
+
       div.unbreakable {
         page-break-inside: avoid
       }
-      
+
       .big {
         font-size: larger
       }
-      
+
       .small {
         font-size: smaller
       }
-      
+
       .underline {
         text-decoration: underline
       }
-      
+
       .overline {
         text-decoration: overline
       }
-      
+
       .line-through {
         text-decoration: line-through
       }
-      
+
       .aqua {
         color: #00bfbf
       }
-      
+
       .aqua-background {
         background: #00fafa
       }
-      
+
       .black {
         color: #000
       }
-      
+
       .black-background {
         background: #000
       }
-      
+
       .blue {
         color: #0000bf
       }
-      
+
       .blue-background {
         background: #0000fa
       }
-      
+
       .fuchsia {
         color: #bf00bf
       }
-      
+
       .fuchsia-background {
         background: #fa00fa
       }
-      
+
       .gray {
         color: #606060
       }
-      
+
       .gray-background {
         background: #7d7d7d
       }
-      
+
       .green {
         color: #006000
       }
-      
+
       .green-background {
         background: #007d00
       }
-      
+
       .lime {
         color: #00bf00
       }
-      
+
       .lime-background {
         background: #00fa00
       }
-      
+
       .maroon {
         color: #600000
       }
-      
+
       .maroon-background {
         background: #7d0000
       }
-      
+
       .navy {
         color: #000060
       }
-      
+
       .navy-background {
         background: #00007d
       }
-      
+
       .olive {
         color: #606000
       }
-      
+
       .olive-background {
         background: #7d7d00
       }
-      
+
       .purple {
         color: #600060
       }
-      
+
       .purple-background {
         background: #7d007d
       }
-      
+
       .red {
         color: #bf0000
       }
-      
+
       .red-background {
         background: #fa0000
       }
-      
+
       .silver {
         color: #909090
       }
-      
+
       .silver-background {
         background: #bcbcbc
       }
-      
+
       .teal {
         color: #006060
       }
-      
+
       .teal-background {
         background: #007d7d
       }
-      
+
       .white {
         color: #bfbfbf
       }
-      
+
       .white-background {
         background: #fafafa
       }
-      
+
       .yellow {
         color: #bfbf00
       }
-      
+
       .yellow-background {
         background: #fafa00
       }
-      
+
       span.icon > .fa {
         cursor: default
       }
-      
+
       a span.icon > .fa {
         cursor: inherit
       }
-      
+
       .admonitionblock td.icon [class^="fa icon-"] {
         font-size: 2.5em;
         text-shadow: 1px 1px 2px rgba(0, 0, 0, .5);
         cursor: default
       }
-      
+
       .admonitionblock td.icon .icon-note::before {
         content: "\f05a";
         color: #19407c
       }
-      
+
       .admonitionblock td.icon .icon-tip::before {
         content: "\f0eb";
         text-shadow: 1px 1px 2px rgba(155, 155, 0, .8);
         color: #111
       }
-      
+
       .admonitionblock td.icon .icon-warning::before {
         content: "\f071";
         color: #bf6900
       }
-      
+
       .admonitionblock td.icon .icon-caution::before {
         content: "\f06d";
         color: #bf3400
       }
-      
+
       .admonitionblock td.icon .icon-important::before {
         content: "\f06a";
         color: #bf0000
       }
-      
+
       .conum[data-value] {
         display: inline-block;
         color: #fff !important;
@@ -1916,219 +1916,219 @@
         font-style: normal;
         font-weight: bold
       }
-      
+
       .conum[data-value] * {
         color: #fff !important
       }
-      
+
       .conum[data-value] + b {
         display: none
       }
-      
+
       .conum[data-value]::after {
         content: attr(data-value)
       }
-      
+
       pre .conum[data-value] {
         position: relative;
         top: -.125em
       }
-      
+
       b.conum * {
         color: inherit !important
       }
-      
+
       .conum:not([data-value]):empty {
         display: none
       }
-      
+
       dt, th.tableblock, td.content, div.footnote {
         text-rendering: optimizeLegibility
       }
-      
+
       h1, h2, p, td.content, span.alt {
         letter-spacing: -.01em
       }
-      
+
       p strong, td.content strong, div.footnote strong {
         letter-spacing: -.005em
       }
-      
+
       p, blockquote, dt, td.content, span.alt {
         font-size: 1.0625rem
       }
-      
+
       p {
         margin-bottom: 1.25rem
       }
-      
+
       .sidebarblock p, .sidebarblock dt, .sidebarblock td.content, p.tableblock {
         font-size: 1em
       }
-      
+
       .exampleblock > .content {
         background: #fffef7;
         border-color: #e0e0dc;
         -webkit-box-shadow: 0 1px 4px #e0e0dc;
         box-shadow: 0 1px 4px #e0e0dc
       }
-      
+
       .print-only {
         display: none !important
       }
-      
+
       @page {
         margin: 1.25cm .75cm
       }
-      
+
       @media print {
         * {
           -webkit-box-shadow: none !important;
           box-shadow: none !important;
           text-shadow: none !important
         }
-      
+
         html {
           font-size: 80%
         }
-      
+
         a {
           color: inherit !important;
           text-decoration: underline !important
         }
-      
+
         a.bare, a[href^="#"], a[href^="mailto:"] {
           text-decoration: none !important
         }
-      
+
         a[href^="http:"]:not(.bare)::after, a[href^="https:"]:not(.bare)::after {
           content: "(" attr(href) ")";
           display: inline-block;
           font-size: .875em;
           padding-left: .25em
         }
-      
+
         abbr[title]::after {
           content: " (" attr(title) ")"
         }
-      
+
         pre, blockquote, tr, img, object, svg {
           page-break-inside: avoid
         }
-      
+
         thead {
           display: table-header-group
         }
-      
+
         svg {
           max-width: 100%
         }
-      
+
         p, blockquote, dt, td.content {
           font-size: 1em;
           orphans: 3;
           widows: 3
         }
-      
+
         h2, h3, #toctitle, .sidebarblock > .content > .title {
           page-break-after: avoid
         }
-      
+
         #toc, .sidebarblock, .exampleblock > .content {
           background: none !important
         }
-      
+
         #toc {
           border-bottom: 1px solid #dddddf !important;
           padding-bottom: 0 !important
         }
-      
+
         body.book #header {
           text-align: center
         }
-      
+
         body.book #header > h1:first-child {
           border: 0 !important;
           margin: 2.5em 0 1em
         }
-      
+
         body.book #header .details {
           border: 0 !important;
           display: block;
           padding: 0 !important
         }
-      
+
         body.book #header .details span:first-child {
           margin-left: 0 !important
         }
-      
+
         body.book #header .details br {
           display: block
         }
-      
+
         body.book #header .details br + span::before {
           content: none !important
         }
-      
+
         body.book #toc {
           border: 0 !important;
           text-align: left !important;
           padding: 0 !important;
           margin: 0 !important
         }
-      
+
         body.book #toc, body.book #preamble, body.book h1.sect0, body.book .sect1 > h2 {
           page-break-before: always
         }
-      
+
         .listingblock code[data-lang]::before {
           display: block
         }
-      
+
         #footer {
           padding: 0 .9375em
         }
-      
+
         .hide-on-print {
           display: none !important
         }
-      
+
         .print-only {
           display: block !important
         }
-      
+
         .hide-for-print {
           display: none !important
         }
-      
+
         .show-for-print {
           display: inherit !important
         }
       }
-      
+
       @media print, amzn-kf8 {
         #header > h1:first-child {
           margin-top: 1.25rem
         }
-      
+
         .sect1 {
           padding: 0 !important
         }
-      
+
         .sect1 + .sect1 {
           border: 0
         }
-      
+
         #footer {
           background: none
         }
-      
+
         #footer-text {
           color: rgba(0, 0, 0, .6);
           font-size: .9em
         }
       }
-      
+
       @media amzn-kf8 {
         #header, #content, #footnotes, #footer {
           padding: 0
@@ -2150,14 +2150,14 @@
           <li><a href="#_tags">Tags</a></li>
         </ul>
       </li>
-    
+
         <li><a href="#_securityscheme">Sicherheit</a>
           <ul class="sectlevel2">
               <li><a href="#_oauth2">
                 OAuth Authorization</a></li>
           </ul>
         </li>
-    
+
       <li><a href="#_paths">Ressourcen</a>
             <ul class="sectlevel2">
               <li><a href="#_api_Version1">Version1</a>
@@ -2192,7 +2192,7 @@
               </li>
             </ul>
       </li>
-    
+
       <li><a href="#_definitions">Definitionen</a>
         <ul class="sectlevel2">
               <li><a href="#_AnnuitaetenDarlehensWunsch">AnnuitaetenDarlehensWunsch</a></li>
@@ -2281,7 +2281,7 @@
               <li><a href="#_ZwischenFinanzierungsWunsch">ZwischenFinanzierungsWunsch</a></li>
         </ul>
       </li>
-    
+
       <li><a href="#_misc">Weitere Informationen</a>
         <ul class="sectlevel2">
           <li><a href="#_miscProduktanbieter">Bezeichnung Produktanbieter</a></li>
@@ -2302,7 +2302,7 @@
           <div class="sect2">
             <h3 id="_aktuelle_version">Aktuelle Version</h3>
             <div class="paragraph">
-              <p><em>Version</em> : 2.7.9</p>
+              <p><em>Version</em> : 2.7.10</p>
             </div>
           </div>
         <div class="sect2">
@@ -2332,7 +2332,7 @@
             <div class="paragraph">
               <p><em>Typ</em> : oauth2<br>
                   <em>Flow</em> : application<br>
-                  
+
                   <em>Token URL</em> : <a href="https://api.europace.de/auth/access-token" class="bare">https://api.europace.de/auth/access-token</a>
               </p>
             </div>
@@ -2378,7 +2378,7 @@
               <div class="paragraph">
                 <p></p>
               </div>
-  
+
                 <div class="sect3">
                   <h4 id="_resource_getFinanzierungsVorschlaege">Ermittle Ergebnisse (<span class="nickname">getFinanzierungsVorschlaege</span>)</h4>
                   <div class="literalblock">
@@ -2417,11 +2417,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
-                                  
-                                  
+
+
+
                                   <strong>Body</strong>
-                                  
+
                                 </p>
                               </div>
                             </div>
@@ -2454,10 +2454,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -2490,10 +2490,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -2525,11 +2525,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
-                                  
+
+
                                   <strong>Query</strong>
-                                  
-                                  
+
+
                                 </p>
                               </div>
                             </div>
@@ -2561,11 +2561,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
-                                  
+
+
                                   <strong>Query</strong>
-                                  
-                                  
+
+
                                 </p>
                               </div>
                             </div>
@@ -2942,10 +2942,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -2977,11 +2977,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -3014,10 +3014,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -3049,11 +3049,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
-                                  
+
+
                                   <strong>Query</strong>
-                                  
-                                  
+
+
                                 </p>
                               </div>
                             </div>
@@ -3085,11 +3085,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
-                                  
+
+
                                   <strong>Query</strong>
-                                  
-                                  
+
+
                                 </p>
                               </div>
                             </div>
@@ -3402,7 +3402,7 @@
               <div class="paragraph">
                 <p></p>
               </div>
-  
+
                 <div class="sect3">
                   <h4 id="_resource_ermittleErgebnisse">Ermittlung erzeugen (<span class="nickname">ermittleErgebnisse</span>)</h4>
                   <div class="literalblock">
@@ -3442,10 +3442,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -3477,11 +3477,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
-                                  
-                                  
+
+
+
                                   <strong>Body</strong>
-                                  
+
                                 </p>
                               </div>
                             </div>
@@ -3514,10 +3514,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -3549,11 +3549,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
-                                  
+
+
                                   <strong>Query</strong>
-                                  
-                                  
+
+
                                 </p>
                               </div>
                             </div>
@@ -3585,11 +3585,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
-                                  
+
+
                                   <strong>Query</strong>
-                                  
-                                  
+
+
                                 </p>
                               </div>
                             </div>
@@ -3621,11 +3621,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
-                                  
+
+
                                   <strong>Query</strong>
-                                  
-                                  
+
+
                                 </p>
                               </div>
                             </div>
@@ -3657,11 +3657,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
-                                  
+
+
                                   <strong>Query</strong>
-                                  
-                                  
+
+
                                 </p>
                               </div>
                             </div>
@@ -3693,11 +3693,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
-                                  
+
+
                                   <strong>Query</strong>
-                                  
-                                  
+
+
                                 </p>
                               </div>
                             </div>
@@ -4074,10 +4074,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -4109,11 +4109,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -4146,10 +4146,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -4495,10 +4495,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -4530,11 +4530,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -4566,11 +4566,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -4603,10 +4603,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -4952,10 +4952,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -4987,11 +4987,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -5024,10 +5024,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -5373,10 +5373,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -5408,11 +5408,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -5445,10 +5445,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -5794,10 +5794,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -5829,11 +5829,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -5866,10 +5866,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -6215,10 +6215,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -6250,11 +6250,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -6286,11 +6286,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -6323,10 +6323,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -6672,10 +6672,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -6707,11 +6707,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -6743,11 +6743,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -6780,10 +6780,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -6815,11 +6815,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
-                                  
+
+
                                   <strong>Query</strong>
-                                  
-                                  
+
+
                                 </p>
                               </div>
                             </div>
@@ -7165,10 +7165,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -7200,11 +7200,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -7236,11 +7236,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -7273,10 +7273,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -7622,10 +7622,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -7657,11 +7657,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -7693,11 +7693,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -7730,10 +7730,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -8079,10 +8079,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -8114,11 +8114,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -8150,11 +8150,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -8186,11 +8186,11 @@
                             <div class="content">
                               <div class="paragraph">
                                 <p>
-                                  
+
                                   <strong>Path</strong>
-                                  
-                                  
-                                  
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -8223,10 +8223,10 @@
                               <div class="paragraph">
                                 <p>
                                   <strong>Header</strong>
-                                  
-                                  
-                                  
-                                  
+
+
+
+
                                 </p>
                               </div>
                             </div>
@@ -8539,7 +8539,7 @@
               <div class="paragraph">
                 <p></p>
               </div>
-  
+
                 <div class="sect3">
                   <h4 id="_resource_getBaufiSmartApiVersion"> (<span class="nickname">getBaufiSmartApiVersion</span>)</h4>
                   <div class="literalblock">
@@ -8832,7 +8832,7 @@
                   </div>
                 </div>
             </div>
-  
+
     </div>
   </div>
   <div class="sect1">
@@ -8874,7 +8874,7 @@
                     <div class="content">
                       <div class="paragraph">
                         <p><strong>darlehensBetrag</strong>
-                          
+
                         </p>
                       </div>
                     </div>
@@ -8890,10 +8890,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -8920,10 +8920,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">array[String]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -8950,10 +8950,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -8964,7 +8964,7 @@
                     <div class="content">
                       <div class="paragraph">
                         <p><strong>tilgungsWunsch</strong>
-                          
+
                         </p>
                       </div>
                     </div>
@@ -8980,10 +8980,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_TilgungsWunsch">TilgungsWunsch</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9010,10 +9010,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9040,10 +9040,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9070,10 +9070,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9100,10 +9100,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9130,10 +9130,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9160,10 +9160,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9212,10 +9212,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9242,7 +9242,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -9250,8 +9250,8 @@
                                 <li>FRAU</li>                                <li>HERR</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9278,10 +9278,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Postadresse">Postadresse</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9308,10 +9308,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Beschaeftigung">Beschaeftigung</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9338,10 +9338,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9368,7 +9368,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -9376,8 +9376,8 @@
                                 <li>GESCHIEDEN</li>                                <li>GETRENNT_LEBEND</li>                                <li>LEBENSPARTNERSCHAFT</li>                                <li>LEDIG</li>                                <li>VERHEIRATET</li>                                <li>VERWITWET</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9404,10 +9404,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9434,10 +9434,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9464,10 +9464,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9494,10 +9494,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9524,10 +9524,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Staat">Staat</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9554,10 +9554,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9584,10 +9584,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9614,10 +9614,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9644,10 +9644,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9674,10 +9674,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Postadresse">Postadresse</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9704,10 +9704,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9734,10 +9734,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9764,10 +9764,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9794,10 +9794,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_LegitimationsDaten">LegitimationsDaten</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9824,7 +9824,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -9832,8 +9832,8 @@
                                 <li>VISUM</li>                                <li>AUFENTHALTS_ERLAUBNIS</li>                                <li>NIEDERLASSUNGS_ERLAUBNIS</li>                                <li>DAUERAUFENTHALT_EU</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9860,10 +9860,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9890,10 +9890,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9920,10 +9920,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9950,10 +9950,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -9980,10 +9980,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10010,10 +10010,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10040,10 +10040,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10070,10 +10070,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10122,10 +10122,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10174,10 +10174,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10204,7 +10204,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -10212,8 +10212,8 @@
                                 <li>STELLPLATZ</li>                                <li>CARPORT</li>                                <li>GARAGE</li>                                <li>DOPPEL_GARAGE</li>                                <li>KELLER_GARAGE</li>                                <li>TIEFGARAGEN_STELLPLATZ</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10262,10 +10262,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10292,10 +10292,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10322,7 +10322,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -10330,8 +10330,8 @@
                                 <li>KEIN_EINSATZ</li>                                <li>ABTRETEN</li>                                <li>AUFLOESEN</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10358,10 +10358,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10388,10 +10388,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10418,10 +10418,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10470,10 +10470,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">array[String]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10500,10 +10500,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10530,10 +10530,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10560,10 +10560,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10590,10 +10590,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10620,10 +10620,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10672,10 +10672,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10702,10 +10702,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10732,10 +10732,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10762,10 +10762,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10792,10 +10792,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10822,10 +10822,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10852,10 +10852,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10882,10 +10882,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10912,10 +10912,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10942,10 +10942,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -10972,10 +10972,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11002,10 +11002,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11032,10 +11032,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11062,10 +11062,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11092,10 +11092,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11122,10 +11122,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11152,10 +11152,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11182,10 +11182,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11212,10 +11212,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_ProduktAnbieter">ProduktAnbieter</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11242,10 +11242,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_ProduktAnbieter">ProduktAnbieter</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11272,10 +11272,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11302,10 +11302,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_SonderZahlung">array[SonderZahlung]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11332,10 +11332,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11362,10 +11362,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11392,10 +11392,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">array[String]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11422,10 +11422,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11474,10 +11474,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11504,10 +11504,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11534,10 +11534,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11564,10 +11564,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11594,10 +11594,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11624,10 +11624,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_ProduktAnbieter">ProduktAnbieter</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11654,10 +11654,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11684,10 +11684,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11714,10 +11714,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11744,10 +11744,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_SparPhase">SparPhase</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11774,10 +11774,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_TilgungsPhase">TilgungsPhase</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11804,10 +11804,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_SonderZahlung">array[SonderZahlung]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11834,10 +11834,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11864,10 +11864,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11894,10 +11894,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11946,10 +11946,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -11976,7 +11976,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">array[String]</a>
                           <div>
                             Mögliche Werte:
@@ -11984,8 +11984,8 @@
 
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12012,10 +12012,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">array[String]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12042,7 +12042,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -12050,8 +12050,8 @@
                                 <li>SOFORTZAHLUNG</li>                                <li>VERRECHNUNG</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12078,10 +12078,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12108,10 +12108,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12138,10 +12138,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12168,10 +12168,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12198,10 +12198,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12228,10 +12228,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12258,10 +12258,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12288,7 +12288,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -12296,8 +12296,8 @@
                                 <li>ZINS_ABSICHERUNG</li>                                <li>TILGUNGS_AUSGESETZT</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12324,10 +12324,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12354,10 +12354,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_SonderZahlung">array[SonderZahlung]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12384,7 +12384,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -12392,8 +12392,8 @@
                                 <li>SONDERZAHLUNG</li>                                <li>VERRECHNUNG</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12442,10 +12442,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_ProduktAnbieter">ProduktAnbieter</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12472,10 +12472,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12502,10 +12502,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12554,10 +12554,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12584,10 +12584,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12636,7 +12636,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -12644,8 +12644,8 @@
                                 <li>ANGESTELLTER</li>                                <li>ARBEITER</li>                                <li>BEAMTER</li>                                <li>FREIBERUFLER</li>                                <li>SELBSTAENDIGER</li>                                <li>RENTNER</li>                                <li>HAUSFRAU</li>                                <li>ARBEITSLOSER</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12672,7 +12672,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -12680,8 +12680,8 @@
                                 <li>LANDWIRTSCHAFT_FORSTWIRTSCHAFT_FISCHEREI</li>                                <li>BERGBAU_GEWINNUNG_VON_STEINEN_UND_ERDEN</li>                                <li>VERARBEITENDES_GEWERBE</li>                                <li>WASSERVERSORGUNG</li>                                <li>ENERGIEVERSORGUNG</li>                                <li>BAUGEWERBE</li>                                <li>HANDEL_INSTANDHALTUNG_VON_KRAFTFAHRZEUGEN</li>                                <li>VERKEHR_LOGISTIK</li>                                <li>GASTGEWERBE</li>                                <li>INFORMATION_KOMMUNIKATION</li>                                <li>FINANZ_UND_VERSICHERUNGSDIENSTLEISTUNGEN</li>                                <li>GRUNDSTÜCKS_UND_WOHNUNGSWESEN</li>                                <li>FREIBERUFLICHE_WISSENSCHAFTLICHE_UND_TECHNISCHE_DIENSTLEISTUNGEN</li>                                <li>SONSTIGE_WIRTSCHAFTLICHE_DIENSTLEISTUNGEN</li>                                <li>OEFFENTLICHE_VERWALTUNG_VERTEIDIGUNG_SOZIALVERSICHERUNG</li>                                <li>ERZIEHUNG_UNTERRICHT</li>                                <li>GESUNDHEIT_UND_SOZIALWESEN</li>                                <li>KUNST_UNTERHALTUNG_ERHOLUNG</li>                                <li>SONSTIGE_DIENSTLEISTUNGEN</li>                                <li>PRIVATE_HAUSHALTE</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12708,10 +12708,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_double">Double</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12738,10 +12738,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12768,7 +12768,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -12776,8 +12776,8 @@
                                 <li>BEFRISTET</li>                                <li>UNBEFRISTET</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12804,10 +12804,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12834,10 +12834,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12864,10 +12864,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12894,10 +12894,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12924,10 +12924,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12954,7 +12954,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -12962,8 +12962,8 @@
                                 <li>ALTENPFLEGER</li>                                <li>AMBULANTER_KRANKENPFLEGER</li>                                <li>ANWALT</li>                                <li>APOTHEKER</li>                                <li>ARCHITEKT</li>                                <li>ARZT</li>                                <li>BESTATTER</li>                                <li>DATENSCHUTZBEAUFTRAGTER</li>                                <li>DEKORATEUR</li>                                <li>DIAETASSISTENT</li>                                <li>DOLMETSCHER</li>                                <li>EDV_BERATER</li>                                <li>ERGOTHERAPEUT</li>                                <li>ERNAEHRUNGSBERATER</li>                                <li>FOTOGRAF</li>                                <li>GEOGRAF</li>                                <li>GRAFIKDESIGNER</li>                                <li>GRAFIKER</li>                                <li>HEBAMME</li>                                <li>HEILMASSEUR</li>                                <li>HEILPRAKTIKER</li>                                <li>HISTORIKER</li>                                <li>INFORMATIKER</li>                                <li>INGENIEUR</li>                                <li>INSOLVENZVERWALTER</li>                                <li>JOURNALIST</li>                                <li>KLASSISCHER_KONZERTMUSIKER</li>                                <li>KONSTRUKTEUR</li>                                <li>KRANKENGYMNAST</li>                                <li>KRANKENPFLEGER</li>                                <li>KRANKENSCHWESTER</li>                                <li>LOGOPAEDE</li>                                <li>MEDIZINISCH_TECHN_ASSISTENT</li>                                <li>NOTAR</li>                                <li>OPERNSAENGER</li>                                <li>PERSONALBERATER</li>                                <li>PHYSIOTHERAPEUT</li>                                <li>PSYCHOLOGE</li>                                <li>RAUMAUSSTATTER</li>                                <li>RUNDFUNKSPRECHER</li>                                <li>SACHVERSTAENDIGER</li>                                <li>STADTPLANER</li>                                <li>STATIKER</li>                                <li>STEUERBERATER</li>                                <li>TIERARZT</li>                                <li>UNTERNEHMENSBERATER</li>                                <li>VERMITTLER</li>                                <li>WIRTSCH_BUCHPRUEFER_REVISOR</li>                                <li>ZAHNARZT</li>                                <li>ZAHNTECHNIKER</li>                                <li>SONSTIGES</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -12990,10 +12990,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13020,10 +13020,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_SituationNachRenteneintritt">SituationNachRenteneintritt</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13050,10 +13050,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Staat">Staat</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13102,10 +13102,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13132,10 +13132,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Postadresse">Postadresse</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13162,10 +13162,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Autostellplatz">array[Autostellplatz]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13192,10 +13192,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Erbbaurecht">Erbbaurecht</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13222,10 +13222,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_GrundbuchAngabe">GrundbuchAngabe</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13252,10 +13252,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13282,10 +13282,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_EffektivZinsErhoehendeKosten">EffektivZinsErhoehendeKosten</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13312,10 +13312,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13342,7 +13342,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -13350,8 +13350,8 @@
                                 <li>GEHOBEN</li>                                <li>MITTEL</li>                                <li>EINFACH</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13378,10 +13378,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13408,10 +13408,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13438,10 +13438,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13468,10 +13468,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13498,10 +13498,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13528,10 +13528,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Grundstueck">Grundstueck</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13558,10 +13558,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Gebaeude">Gebaeude</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13588,7 +13588,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -13596,8 +13596,8 @@
                                 <li>GRUNDSTUECK</li>                                <li>EIGENTUMSWOHNUNG</li>                                <li>HAUS</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13624,10 +13624,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13654,7 +13654,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -13662,8 +13662,8 @@
                                 <li>KEIN_EINSATZ</li>                                <li>VERKAUFEN</li>                                <li>ALS_ZUSATZSICHERHEIT</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13690,10 +13690,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13720,10 +13720,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13750,10 +13750,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BestehendesDarlehen">array[BestehendesDarlehen]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13802,10 +13802,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13832,10 +13832,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13862,10 +13862,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13892,10 +13892,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13922,10 +13922,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13952,10 +13952,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_ProduktAnbieter">ProduktAnbieter</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -13982,10 +13982,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14012,10 +14012,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14042,10 +14042,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14072,7 +14072,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -14080,8 +14080,8 @@
                                 <li>KEIN_EINSATZ</li>                                <li>ABTRETEN</li>                                <li>AUFLOESEN</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14108,10 +14108,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14138,10 +14138,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14168,10 +14168,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14198,10 +14198,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14228,10 +14228,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14258,10 +14258,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14310,10 +14310,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14340,10 +14340,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14370,10 +14370,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14400,7 +14400,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -14408,8 +14408,8 @@
                                 <li>BAUSPARDARLEHEN</li>                                <li>FOERDERDARLEHEN</li>                                <li>IMMOBILIENDARLEHEN</li>                                <li>SONSTIGES_DARLEHEN</li>                                <li>PRIVATDARLEHEN</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14436,10 +14436,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_ProduktAnbieter">ProduktAnbieter</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14466,10 +14466,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14496,10 +14496,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14526,10 +14526,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14556,10 +14556,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14586,10 +14586,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14616,10 +14616,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14646,10 +14646,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14676,10 +14676,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14706,7 +14706,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -14714,8 +14714,8 @@
                                 <li>BRIEF_GRUNDSCHULD</li>                                <li>BUCH_GRUNDSCHULD</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14764,10 +14764,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14794,10 +14794,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14824,10 +14824,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14854,7 +14854,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -14862,8 +14862,8 @@
                                 <li>BAUSPARDARLEHEN</li>                                <li>FOERDERDARLEHEN</li>                                <li>IMMOBILIENDARLEHEN</li>                                <li>SONSTIGES_DARLEHEN</li>                                <li>PRIVATDARLEHEN</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14890,10 +14890,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_ProduktAnbieter">ProduktAnbieter</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14920,10 +14920,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14950,10 +14950,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -14980,10 +14980,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15010,10 +15010,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15040,10 +15040,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15070,10 +15070,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15100,10 +15100,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15130,10 +15130,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15160,7 +15160,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -15168,8 +15168,8 @@
                                 <li>BRIEF_GRUNDSCHULD</li>                                <li>BUCH_GRUNDSCHULD</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15196,7 +15196,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -15204,8 +15204,8 @@
                                 <li>ABLOESEN</li>                                <li>TRITT_IM_RANG_ZURUECK</li>                                <li>TRITT_NICHT_IM_RANG_ZURUECK</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15254,10 +15254,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15284,7 +15284,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -15292,8 +15292,8 @@
                                 <li>ANNUITAETEN_DARLEHEN</li>                                <li>FORWARD_DARLEHEN</li>                                <li>REGIONAL_FOERDER_DARLEHEN</li>                                <li>KFW_DARLEHEN</li>                                <li>PRIVAT_DARLEHEN</li>                                <li>ZWISCHEN_FINANZIERUNG</li>                                <li>VARIABLES_DARLEHEN</li>                                <li>BAUSPARVERTRAG</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15320,7 +15320,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -15328,8 +15328,8 @@
                                 <li>PROGRAMM_124</li>                                <li>PROGRAMM_141</li>                                <li>PROGRAMM_151</li>                                <li>PROGRAMM_152</li>                                <li>PROGRAMM_153</li>                                <li>PROGRAMM_155</li>                                <li>PROGRAMM_159</li>                                <li>PROGRAMM_167</li>                                <li>PROGRAMM_261</li>                                <li>PROGRAMM_262</li>                                <li>PROGRAMM_297</li>                                <li>PROGRAMM_298</li>                                <li>PROGRAMM_300</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15356,10 +15356,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15386,10 +15386,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15416,10 +15416,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_EffektivZinsRelevanteKosten">EffektivZinsRelevanteKosten</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15446,10 +15446,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15476,10 +15476,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15506,10 +15506,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15536,10 +15536,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_ProduktAnbieter">ProduktAnbieter</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15566,10 +15566,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_ProduktAnbieter">ProduktAnbieter</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15596,10 +15596,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15626,10 +15626,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_ZinsBindung">ZinsBindung</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15656,10 +15656,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Tilgung">Tilgung</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15686,10 +15686,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Bereitstellung">Bereitstellung</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15716,10 +15716,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15746,10 +15746,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15776,10 +15776,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15828,10 +15828,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15858,10 +15858,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_AnnuitaetenDarlehensWunsch">AnnuitaetenDarlehensWunsch</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15888,10 +15888,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_ForwardDarlehensWunsch">ForwardDarlehensWunsch</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15918,10 +15918,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_RegionalFoerderDarlehensWunsch">RegionalFoerderDarlehensWunsch</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15948,10 +15948,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_KfwDarlehensWunsch">KfwDarlehensWunsch</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -15978,10 +15978,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_PrivatDarlehensWunsch">PrivatDarlehensWunsch</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16008,10 +16008,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_ZwischenFinanzierungsWunsch">ZwischenFinanzierungsWunsch</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16038,10 +16038,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_VariablesDarlehensWunsch">VariablesDarlehensWunsch</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16090,10 +16090,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16120,10 +16120,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16150,10 +16150,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16180,10 +16180,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16210,10 +16210,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16262,10 +16262,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16292,10 +16292,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16322,10 +16322,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16352,10 +16352,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16382,10 +16382,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16412,10 +16412,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16464,10 +16464,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16494,10 +16494,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16546,10 +16546,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16598,10 +16598,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16628,10 +16628,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">array[String]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16658,10 +16658,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16688,10 +16688,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16718,10 +16718,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16748,10 +16748,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16778,10 +16778,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16808,10 +16808,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16838,10 +16838,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16890,10 +16890,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16920,10 +16920,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16950,7 +16950,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -16958,8 +16958,8 @@
                                 <li>ANDERE</li>                                <li>OEFFENTLICH_KIRCHLICH</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -16986,10 +16986,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17038,10 +17038,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17068,10 +17068,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17098,10 +17098,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17128,10 +17128,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Partner">Partner</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17158,10 +17158,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Partner">Partner</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17188,10 +17188,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Partner">Partner</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17218,10 +17218,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Bankverbindung">Bankverbindung</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17248,10 +17248,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Haushalt">array[Haushalt]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17278,10 +17278,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_FinanzierungsObjekt">FinanzierungsObjekt</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17292,7 +17292,7 @@
                     <div class="content">
                       <div class="paragraph">
                         <p><strong>vorhaben</strong>
-                          
+
                         </p>
                       </div>
                     </div>
@@ -17308,10 +17308,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Vorhaben">Vorhaben</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17338,10 +17338,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_LeadTracking">LeadTracking</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17368,7 +17368,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -17376,8 +17376,8 @@
                                 <li>TEST_MODUS</li>                                <li>ECHT_GESCHAEFT</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17426,10 +17426,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17456,10 +17456,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17486,10 +17486,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17516,10 +17516,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17546,10 +17546,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Darlehen">array[Darlehen]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17576,10 +17576,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Beleihung">array[Beleihung]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17606,10 +17606,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Meldung">array[Meldung]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17636,7 +17636,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -17644,8 +17644,8 @@
                                 <li>MACHBAR</li>                                <li>UNTER_VORBEHALT</li>                                <li>NICHT_MACHBAR</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17672,10 +17672,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_DateTime">Date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17702,10 +17702,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_DateTime">Date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17732,10 +17732,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BausparAngebot">array[BausparAngebot]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17762,7 +17762,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -17770,8 +17770,8 @@
                                 <li>NICHT_ANGEPASST</li>                                <li>ANGEPASST</li>                                <li>ALTERNATIV</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17798,10 +17798,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Links">Links</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17850,10 +17850,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Ergebnis">array[Ergebnis]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17880,10 +17880,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Links">Links</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17932,10 +17932,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17962,10 +17962,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Ergebnis">array[Ergebnis]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -17992,10 +17992,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Links">Links</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18044,10 +18044,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18074,10 +18074,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_ErfassteDaten">ErfassteDaten</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18104,10 +18104,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18134,10 +18134,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18164,10 +18164,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18194,10 +18194,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Links">Links</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18224,10 +18224,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_DateTime">Date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18276,10 +18276,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18306,10 +18306,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18336,10 +18336,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18366,10 +18366,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18396,10 +18396,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18448,10 +18448,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18478,10 +18478,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18508,10 +18508,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18538,10 +18538,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18568,10 +18568,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18598,10 +18598,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18628,10 +18628,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18658,10 +18658,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18688,10 +18688,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18718,10 +18718,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18748,10 +18748,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18778,10 +18778,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18808,10 +18808,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18838,10 +18838,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18868,10 +18868,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18898,10 +18898,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18928,10 +18928,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18958,10 +18958,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -18988,10 +18988,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19018,10 +19018,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19070,10 +19070,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19100,10 +19100,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Postadresse">Postadresse</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19130,10 +19130,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Autostellplatz">array[Autostellplatz]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19160,10 +19160,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Erbbaurecht">Erbbaurecht</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19190,10 +19190,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_GrundbuchAngabe">GrundbuchAngabe</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19220,10 +19220,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19250,10 +19250,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_EffektivZinsErhoehendeKosten">EffektivZinsErhoehendeKosten</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19280,10 +19280,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19310,7 +19310,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -19318,8 +19318,8 @@
                                 <li>GEHOBEN</li>                                <li>MITTEL</li>                                <li>EINFACH</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19346,10 +19346,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19376,10 +19376,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19406,10 +19406,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19436,10 +19436,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19466,10 +19466,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19496,10 +19496,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Grundstueck">Grundstueck</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19526,10 +19526,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Gebaeude">Gebaeude</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19556,7 +19556,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -19564,8 +19564,8 @@
                                 <li>GRUNDSTUECK</li>                                <li>EIGENTUMSWOHNUNG</li>                                <li>HAUS</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19592,10 +19592,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19622,10 +19622,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BestehendesDarlehenDesFinanzierungsObjekts">array[BestehendesDarlehenDesFinanzierungsObjekts]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19674,10 +19674,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19688,7 +19688,7 @@
                     <div class="content">
                       <div class="paragraph">
                         <p><strong>darlehensWuensche</strong>
-                          
+
                         </p>
                       </div>
                     </div>
@@ -19704,10 +19704,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_DarlehensWunsch">array[DarlehensWunsch]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19734,10 +19734,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BausparWunsch">array[BausparWunsch]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19786,10 +19786,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_MiteigentumsAnteil">MiteigentumsAnteil</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19816,10 +19816,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19846,10 +19846,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19876,10 +19876,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19912,7 +19912,7 @@
                     <div class="content">
                       <div class="paragraph">
                         <p><strong>darlehensBetrag</strong>
-                          
+
                         </p>
                       </div>
                     </div>
@@ -19928,10 +19928,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19958,10 +19958,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">array[String]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -19988,10 +19988,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20002,7 +20002,7 @@
                     <div class="content">
                       <div class="paragraph">
                         <p><strong>tilgungsWunsch</strong>
-                          
+
                         </p>
                       </div>
                     </div>
@@ -20018,10 +20018,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_TilgungsWunsch">TilgungsWunsch</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20048,10 +20048,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20078,10 +20078,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20108,10 +20108,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20138,10 +20138,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20190,7 +20190,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -20198,8 +20198,8 @@
                                 <li>AUSGEBAUT</li>                                <li>TEILWEISE_AUSGEBAUT</li>                                <li>VORHANDEN</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20226,10 +20226,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20256,7 +20256,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -20264,8 +20264,8 @@
                                 <li>EINFACH</li>                                <li>MITTEL</li>                                <li>GEHOBEN</li>                                <li>STARK_GEHOBEN</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20292,10 +20292,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20322,7 +20322,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -20330,8 +20330,8 @@
                                 <li>FACHWERK_MIT_STROH_LEHM</li>                                <li>FACHWERK_MIT_ZIEGELN</li>                                <li>GLAS_STAHL</li>                                <li>HOLZ</li>                                <li>MASSIV</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20358,10 +20358,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20388,10 +20388,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20418,10 +20418,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_GebaeudeFlaeche">GebaeudeFlaeche</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20448,10 +20448,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20478,10 +20478,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20508,10 +20508,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_ModernisierungsAngaben">ModernisierungsAngaben</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20538,10 +20538,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_GebaeudeFlaeche">GebaeudeFlaeche</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20568,10 +20568,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20598,10 +20598,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_MiteigentumsAnteil">MiteigentumsAnteil</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20628,7 +20628,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -20636,8 +20636,8 @@
                                 <li>UNTERGESCHOSS</li>                                <li>ERDGESCHOSS</li>                                <li>ERSTES_OBERGESCHOSS</li>                                <li>ZWEITES_OBERGESCHOSS</li>                                <li>DRITTES_BIS_FUENFTES_OBERGESCHOSS</li>                                <li>AB_SECHSTES_OBERGESCHOSS</li>                                <li>UNBEKANNT</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20664,10 +20664,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20694,7 +20694,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -20702,8 +20702,8 @@
                                 <li>FLACHDACH</li>                                <li>NICHT_AUSGEBAUT</li>                                <li>TEILWEISE_AUSGEBAUT</li>                                <li>VOLL_AUSGEBAUT</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20730,10 +20730,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20760,10 +20760,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20790,7 +20790,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -20798,8 +20798,8 @@
                                 <li>FREISTEHEND</li>                                <li>KOPFHAUS</li>                                <li>MITTELHAUS</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20826,7 +20826,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -20834,8 +20834,8 @@
                                 <li>DOPPELHAUSHAELFTE</li>                                <li>EINFAMILIENHAUS</li>                                <li>MEHRFAMILIENHAUS</li>                                <li>REIHENHAUS</li>                                <li>ZWEIFAMILIENHAUS</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20862,7 +20862,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -20870,8 +20870,8 @@
                                 <li>NICHT_UNTERKELLERT</li>                                <li>TEILWEISE_UNTERKELLERT</li>                                <li>UNTERKELLERT</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20920,10 +20920,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_VermietungsInformationen">VermietungsInformationen</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -20950,10 +20950,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21002,10 +21002,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21032,10 +21032,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21062,10 +21062,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Flurstueck">array[Flurstueck]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21092,10 +21092,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_RechteAbteilung2">RechteAbteilung2</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21122,10 +21122,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21174,7 +21174,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -21182,8 +21182,8 @@
                                 <li>UNBEBAUTES_WOHNGRUNDSTUECK</li>                                <li>UNBEBAUTES_MISCHGRUNDSTUECK</li>                                <li>UNBEBAUTES_GEWERBEGRUNDSTUECK</li>                                <li>LANDWIRTSCHAFTLICHES_GRUNDSTUECK</li>                                <li>SONSTIGES_GRUNDSTUECK</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21210,10 +21210,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21262,10 +21262,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21292,10 +21292,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Antragsteller">array[Antragsteller]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21322,10 +21322,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BestehendeImmobilie">array[BestehendeImmobilie]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21352,10 +21352,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_HaushaltsPositionen">HaushaltsPositionen</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21382,10 +21382,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_VermoegenVerbindlichkeiten">VermoegenVerbindlichkeiten</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21412,10 +21412,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Kind">array[Kind]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21442,10 +21442,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21472,10 +21472,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21502,10 +21502,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21532,10 +21532,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21562,10 +21562,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21614,10 +21614,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_AusgabenMonatlich">array[AusgabenMonatlich]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21644,10 +21644,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BankUndSparguthaben">array[BankUndSparguthaben]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21674,10 +21674,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BestehenderBausparvertrag">array[BestehenderBausparvertrag]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21704,10 +21704,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_EinnahmenMonatlich">array[EinnahmenMonatlich]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21734,10 +21734,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_EinkuenfteAusNebentaetigkeit">array[EinkuenfteAusNebentaetigkeit]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21764,10 +21764,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_EinnahmenMonatlich">array[EinnahmenMonatlich]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21794,10 +21794,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_LebensOderRentenversicherungVermoegen">array[LebensOderRentenversicherungVermoegen]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21824,10 +21824,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_MietAusgaben">array[MietAusgaben]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21854,10 +21854,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Verbindlichkeit">array[Verbindlichkeit]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21884,10 +21884,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_AusgabenMonatlich">array[AusgabenMonatlich]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21914,10 +21914,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Verbindlichkeit">array[Verbindlichkeit]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21944,10 +21944,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Sparplaene">array[Sparplaene]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -21974,10 +21974,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_EinnahmenMonatlich">array[EinnahmenMonatlich]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22004,10 +22004,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_AusgabenMonatlich">array[AusgabenMonatlich]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22034,10 +22034,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_EinnahmenMonatlich">array[EinnahmenMonatlich]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22064,10 +22064,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Verbindlichkeit">array[Verbindlichkeit]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22094,10 +22094,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Vermoegen">array[Vermoegen]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22124,10 +22124,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_AusgabenMonatlich">array[AusgabenMonatlich]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22154,10 +22154,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Wertpapiere">array[Wertpapiere]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22190,7 +22190,7 @@
                     <div class="content">
                       <div class="paragraph">
                         <p><strong>darlehensBetrag</strong>
-                          
+
                         </p>
                       </div>
                     </div>
@@ -22206,10 +22206,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22236,10 +22236,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">array[String]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22266,10 +22266,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22296,10 +22296,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22326,10 +22326,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22356,10 +22356,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22386,7 +22386,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -22394,8 +22394,8 @@
                                 <li>PROGRAMM_124</li>                                <li>PROGRAMM_141</li>                                <li>PROGRAMM_151</li>                                <li>PROGRAMM_152</li>                                <li>PROGRAMM_153</li>                                <li>PROGRAMM_155</li>                                <li>PROGRAMM_159</li>                                <li>PROGRAMM_167</li>                                <li>PROGRAMM_261</li>                                <li>PROGRAMM_262</li>                                <li>PROGRAMM_297</li>                                <li>PROGRAMM_298</li>                                <li>PROGRAMM_300</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22422,7 +22422,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -22430,8 +22430,8 @@
                                 <li>STANDARD_40</li>                                <li>STANDARD_40_PLUS</li>                                <li>STANDARD_40_EEK</li>                                <li>STANDARD_40_NH</li>                                <li>STANDARD_55</li>                                <li>STANDARD_55_EEK</li>                                <li>STANDARD_70</li>                                <li>STANDARD_70_EEK</li>                                <li>STANDARD_85</li>                                <li>STANDARD_85_EEK</li>                                <li>STANDARD_100</li>                                <li>STANDARD_100_EEK</li>                                <li>STANDARD_DENKMAL</li>                                <li>STANDARD_DENKMAL_EEK</li>                                <li>KLIMAFREUNDLICH_STANDARD</li>                                <li>KLIMAFREUNDLICH_QNG</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22458,7 +22458,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -22466,8 +22466,8 @@
                                 <li>STANDARD</li>                                <li>NEUBAU</li>                                <li>SANIERUNG</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22494,10 +22494,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22546,10 +22546,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22576,10 +22576,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22606,10 +22606,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22636,10 +22636,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22666,10 +22666,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22718,10 +22718,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22748,10 +22748,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22778,10 +22778,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22808,10 +22808,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22860,10 +22860,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22890,10 +22890,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22920,10 +22920,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22950,10 +22950,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -22980,10 +22980,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23010,10 +23010,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23040,10 +23040,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23070,10 +23070,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23100,7 +23100,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -23108,8 +23108,8 @@
                                 <li>KAPITALBILDENDE_LEBENSVERSICHERUNG</li>                                <li>FONDSGEBUNDENE_LEBENSVERSICHERUNG</li>                                <li>KAPITALBILDENDE_RENTENVERSICHERUNG</li>                                <li>FONDSGEBUNDENE_RENTENVERSICHERUNG</li>                                <li>RISIKO_LEBENSVERSICHERUNG</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23136,10 +23136,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23166,10 +23166,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23196,7 +23196,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -23204,8 +23204,8 @@
                                 <li>KEIN_EINSATZ</li>                                <li>ABTRETEN</li>                                <li>AUFLOESEN</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23232,10 +23232,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23284,7 +23284,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -23292,8 +23292,8 @@
                                 <li>PERSONALAUSWEIS</li>                                <li>REISEPASS</li>                                <li>ANDERE</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23320,10 +23320,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23350,10 +23350,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23380,10 +23380,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23410,10 +23410,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23462,10 +23462,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23492,10 +23492,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23522,10 +23522,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23552,10 +23552,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23582,10 +23582,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23612,10 +23612,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23642,10 +23642,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23672,10 +23672,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23746,10 +23746,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23776,10 +23776,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23806,10 +23806,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23836,7 +23836,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -23844,8 +23844,8 @@
                                 <li>AUSZAHLUNGS_VORAUSSETZUNG</li>                                <li>MACHBAR</li>                                <li>MACHBARKEITS_HINWEIS</li>                                <li>ANPASSUNG_KUNDENWUNSCH</li>                                <li>ANPASSUNG_VERTRIEBSWUNSCH</li>                                <li>UNBERUECKSICHTIGTE_ANGABE</li>                                <li>KONDITIONEN_UNTER_VORBEHALT_VOLLSTAENDIGER_DATEN</li>                                <li>KONDITIONEN_UNTER_VORBEHALT_EXTERNER_SCHNITTSTELLEN</li>                                <li>MACHBARKEIT_UNTER_VORBEHALT_VOLLSTAENDIGER_DATEN</li>                                <li>MACHBARKEIT_UNTER_VORBEHALT_EXTERNER_SCHNITTSTELLEN</li>                                <li>MACHBAR_UNTER_VORBEHALT_PRODUZENT</li>                                <li>NICHT_MACHBAR</li>                                <li>NICHT_ANBIETBAR</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23872,7 +23872,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -23880,8 +23880,8 @@
                                 <li>ANTRAGSTELLER</li>                                <li>OBJEKT</li>                                <li>VORHABEN</li>                                <li>ALTERNATIV</li>                                <li>ANPASSUNG</li>                                <li>UNBERUECKSICHTIGTE_ANGABE</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23930,10 +23930,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Meldung">array[Meldung]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -23960,10 +23960,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Links">Links</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24012,10 +24012,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24042,10 +24042,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24094,10 +24094,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_double">Double</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24124,10 +24124,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24176,10 +24176,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24206,7 +24206,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -24214,8 +24214,8 @@
                                 <li>GERING</li>                                <li>MITTEL</li>                                <li>HOCH</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24242,10 +24242,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24272,10 +24272,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24302,10 +24302,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24332,10 +24332,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24362,10 +24362,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24392,10 +24392,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24422,10 +24422,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24452,10 +24452,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24482,10 +24482,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24534,7 +24534,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -24542,8 +24542,8 @@
                                 <li>ARBEITGEBERDARLEHEN</li>                                <li>BAUSPARDARLEHEN</li>                                <li>OEFFENTLICHES_DARLEHEN</li>                                <li>RATENKREDIT</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24570,10 +24570,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24600,10 +24600,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24630,10 +24630,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24660,10 +24660,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24690,10 +24690,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_ZinsBindung">ZinsBindung</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24742,10 +24742,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24772,10 +24772,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24802,7 +24802,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -24810,8 +24810,8 @@
                                 <li>FRAU</li>                                <li>HERR</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24838,10 +24838,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24868,10 +24868,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24898,10 +24898,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24928,10 +24928,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24958,10 +24958,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -24988,10 +24988,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25018,10 +25018,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25048,10 +25048,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25078,10 +25078,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Postadresse">Postadresse</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25108,10 +25108,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25138,10 +25138,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25168,10 +25168,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25198,10 +25198,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_VertriebsOrganisation">VertriebsOrganisation</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25228,10 +25228,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25258,10 +25258,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25310,10 +25310,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25340,10 +25340,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25370,10 +25370,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25400,10 +25400,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25436,7 +25436,7 @@
                     <div class="content">
                       <div class="paragraph">
                         <p><strong>darlehensBetrag</strong>
-                          
+
                         </p>
                       </div>
                     </div>
@@ -25452,10 +25452,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25482,10 +25482,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">array[String]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25512,10 +25512,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25542,10 +25542,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25594,10 +25594,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25624,10 +25624,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25654,10 +25654,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25684,10 +25684,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Links">Links</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25736,10 +25736,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25766,10 +25766,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25796,10 +25796,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Links">Links</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25848,10 +25848,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25878,10 +25878,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25908,10 +25908,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25944,7 +25944,7 @@
                     <div class="content">
                       <div class="paragraph">
                         <p><strong>darlehensBetrag</strong>
-                          
+
                         </p>
                       </div>
                     </div>
@@ -25960,10 +25960,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -25990,10 +25990,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">array[String]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26020,10 +26020,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26050,10 +26050,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26080,10 +26080,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26110,10 +26110,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26124,7 +26124,7 @@
                     <div class="content">
                       <div class="paragraph">
                         <p><strong>regionalFoerderbankProgramm</strong>
-                          
+
                         </p>
                       </div>
                     </div>
@@ -26140,7 +26140,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -26148,8 +26148,8 @@
                                 <li>L_BANK_KOMBI_DARLEHEN_WOHNEN</li>                                <li>L_BANK_WOHNEN_MIT_KIND</li>                                <li>L_BANK_WOHNEN_MIT_ZUKUNFT</li>                                <li>NRW_BANK_WOHNEIGENTUM</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26198,10 +26198,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26228,10 +26228,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26258,10 +26258,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26288,10 +26288,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26340,10 +26340,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26370,7 +26370,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -26378,8 +26378,8 @@
                                 <li>EINMALIG</li>                                <li>MONATLICH</li>                                <li>VIERTELJAEHRLICH</li>                                <li>HALBJAEHRLICH</li>                                <li>JAEHRLICH</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26406,10 +26406,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26436,10 +26436,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26488,10 +26488,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26518,10 +26518,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26548,10 +26548,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26600,10 +26600,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26630,10 +26630,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26660,7 +26660,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -26668,8 +26668,8 @@
                                 <li>KEIN_EINSATZ</li>                                <li>ABTRETEN</li>                                <li>AUFLOESEN</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26696,10 +26696,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26726,10 +26726,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26756,10 +26756,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26808,10 +26808,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26838,10 +26838,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26890,10 +26890,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26920,10 +26920,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -26950,10 +26950,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27002,10 +27002,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27032,10 +27032,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27062,10 +27062,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27092,10 +27092,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27144,10 +27144,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27174,10 +27174,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27204,10 +27204,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27234,10 +27234,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27264,10 +27264,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27294,10 +27294,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27324,10 +27324,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27354,10 +27354,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BausparWunsch">BausparWunsch</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27406,10 +27406,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27436,10 +27436,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27466,10 +27466,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27496,7 +27496,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -27504,8 +27504,8 @@
                                 <li>ZUR_VERBINDLICHEN_ANGEBOTSANNAHME</li>                                <li>VOR_DER_ERSTEN_AUSZAHLUNG</li>                                <li>VOR_JEDER_AUSZAHLUNG</li>                                <li>VOR_AUSZAHLUNG_LETZTE_RATE</li>                                <li>NACHZUREICHEN_SOBALD_VERFUEGBAR</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27532,7 +27532,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -27540,8 +27540,8 @@
                                 <li>ANTRAGSTELLER</li>                                <li>OBJEKT</li>                                <li>VORHABEN</li>                                <li>ALTERNATIV</li>                                <li>ANPASSUNG</li>                                <li>UNBERUECKSICHTIGTE_ANGABE</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27568,10 +27568,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27620,10 +27620,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Unterlage">array[Unterlage]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27650,10 +27650,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Links">Links</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27686,7 +27686,7 @@
                     <div class="content">
                       <div class="paragraph">
                         <p><strong>darlehensBetrag</strong>
-                          
+
                         </p>
                       </div>
                     </div>
@@ -27702,10 +27702,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27732,10 +27732,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">array[String]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27762,10 +27762,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27776,7 +27776,7 @@
                     <div class="content">
                       <div class="paragraph">
                         <p><strong>tilgungsWunsch</strong>
-                          
+
                         </p>
                       </div>
                     </div>
@@ -27792,10 +27792,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_TilgungsWunsch">TilgungsWunsch</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27844,10 +27844,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27874,10 +27874,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27904,10 +27904,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27934,10 +27934,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -27964,10 +27964,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28016,7 +28016,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -28024,8 +28024,8 @@
                                 <li>EIGENGENUTZT</li>                                <li>TEIL_VERMIETET</li>                                <li>VERMIETET</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28052,10 +28052,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28082,10 +28082,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28134,10 +28134,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28164,10 +28164,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28194,7 +28194,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -28202,8 +28202,8 @@
                                 <li>KEIN_EINSATZ</li>                                <li>ABTRETEN</li>                                <li>AUFLOESEN</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28230,10 +28230,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28260,10 +28260,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28312,10 +28312,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28342,7 +28342,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -28350,8 +28350,8 @@
                                 <li>VERMOEGEN</li>                                <li>VERBINDLICHKEIT</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28378,10 +28378,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28408,10 +28408,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28438,10 +28438,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28490,10 +28490,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_VermoegenVerbindlichkeit">array[VermoegenVerbindlichkeit]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28542,10 +28542,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28572,10 +28572,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28602,10 +28602,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28632,10 +28632,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28662,10 +28662,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28692,10 +28692,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28744,10 +28744,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28774,10 +28774,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28804,10 +28804,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_NachrangigesExternesDarlehen">array[NachrangigesExternesDarlehen]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28834,10 +28834,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_boolean">Boolean</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28864,7 +28864,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -28872,8 +28872,8 @@
                                 <li>ANSCHLUSSFINANZIERUNG</li>                                <li>KAUF</li>                                <li>KAUF_NEUBAU_VOM_BAUTRAEGER</li>                                <li>MODERNISIERUNG_UMBAU_ANBAU</li>                                <li>NEUBAU</li>                                <li>KAPITALBESCHAFFUNG</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28900,10 +28900,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Finanzbedarf">Finanzbedarf</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28914,7 +28914,7 @@
                     <div class="content">
                       <div class="paragraph">
                         <p><strong>finanzierungswunsch</strong>
-                          
+
                         </p>
                       </div>
                     </div>
@@ -28930,10 +28930,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Finanzierungswunsch">Finanzierungswunsch</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -28960,10 +28960,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BausparAngebotExtern">array[BausparAngebotExtern]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29012,10 +29012,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29042,10 +29042,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29072,7 +29072,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -29080,8 +29080,8 @@
                                 <li>KEIN_EINSATZ</li>                                <li>ABTRETEN</li>                                <li>AUFLOESEN</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29108,10 +29108,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29138,10 +29138,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29168,10 +29168,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29220,10 +29220,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Links">Links</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29250,10 +29250,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Zahlungsplan">array[Zahlungsplan]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29302,10 +29302,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29332,7 +29332,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -29340,8 +29340,8 @@
                                 <li>SPARPLAN</li>                                <li>TILGUNGSPLAN</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29368,7 +29368,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -29376,8 +29376,8 @@
                                 <li>ANNUITAETEN_DARLEHEN</li>                                <li>FORWARD_DARLEHEN</li>                                <li>REGIONAL_FOERDER_DARLEHEN</li>                                <li>KFW_DARLEHEN</li>                                <li>PRIVAT_DARLEHEN</li>                                <li>ZWISCHEN_FINANZIERUNG</li>                                <li>VARIABLES_DARLEHEN</li>                                <li>BAUSPARVERTRAG</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29404,10 +29404,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Eintrag">array[Eintrag]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29434,10 +29434,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Eintrag">Eintrag</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29464,10 +29464,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Eintrag">Eintrag</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29494,10 +29494,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Eintrag">Eintrag</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29524,10 +29524,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_Links">Links</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29576,10 +29576,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29606,10 +29606,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29636,10 +29636,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_date">date</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29666,10 +29666,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29702,7 +29702,7 @@
                     <div class="content">
                       <div class="paragraph">
                         <p><strong>darlehensBetrag</strong>
-                          
+
                         </p>
                       </div>
                     </div>
@@ -29718,10 +29718,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29748,10 +29748,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">array[String]</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29778,10 +29778,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_BigDecimal">BigDecimal</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29808,7 +29808,7 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
                           <div>
                             Mögliche Werte:
@@ -29816,8 +29816,8 @@
                                 <li>VORFINANZIERUNG_OEFFENTLICHER_MITTEL</li>                                <li>VERKAUF_EINES_ANDEREN_OBJEKTS</li>                                <li>SONSTIGE_VERWENDUNG</li>
                             </ul>
                           </div>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29844,10 +29844,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_integer">Integer</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -29874,10 +29874,10 @@
                     <div class="content">
                       <div class="paragraph">
                       <p>
-  
+
                           <a href="#_string">String</a>
-  
-  
+
+
                         </p>
                       </div>
                     </div>
@@ -30007,7 +30007,7 @@
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>DZ_HYP</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>DZ HYP AG</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>DZ HYP AG</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>DZ_HYP_EP</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>DZ HYP AG</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>DZ HYP AG</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>DZ_HYP_TEST</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>DZ HYP AG Test</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>DZ HYP AG Test</p>    </div>  </div></td>
-            <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>DZ_HYP_VERTRIEB_EP</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>DZ HYP</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>DZ HYP AG</p>    </div>  </div></td>
+            <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>DZ_HYP_VERTRIEB_EP</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>DZ HYP AG</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>DZ HYP AG</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>DZ_PRIVATBANK</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>DZ PRIVATBANK</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>DZ PRIVATBANK S.A.</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>ERFURTER_BANK</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Erfurter Bank</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Erfurter Bank eG</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>ERGO</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>ERGO</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>ERGO Lebensversicherung AG</p>    </div>  </div></td>
@@ -30914,7 +30914,7 @@
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VR_ELLWANGEN</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR-Bank Ellwangen eG</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR-Bank Ellwangen eG</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VR_ERDING</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR-Bank Erding eG</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR-Bank Erding eG</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VR_ERLANGEN</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR Bank Metropolregion Nürnberg eG</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR Bank Metropolregion Nürnberg eG</p>    </div>  </div></td>
-            <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VR_FEUCHTWANGEN</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR Bank im südlichen Franken</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR-Bank im südlichen Franken eG</p>    </div>  </div></td>
+            <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VR_FEUCHTWANGEN</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR Feuchtwangen-Dinkelsbühl</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR-Bank Feuchtwangen-Dinkelsbühl eG</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VR_FICHTELGEBIRGE</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR-Bank Fichtelgebirge-Frankenwald </p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR-Bank Fichtelgebirge-Frankenwald eG</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VR_FLAEMING</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR-Bank Fläming-Elsterland eG</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR-Bank Fläming-Elsterland eG</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VR_FLENSBURG_SCHLES</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR Bank Nord eG</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR Bank Nord eG</p>    </div>  </div></td>
@@ -30993,7 +30993,6 @@
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VR_WYK_AUF_FOEHR</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Vereinigte VR Bank eG Wyk auf Föhr</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Vereinigte VR Bank eG, Wyk auf Föhr</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VSK_GOCH</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VSK Goch-Kevelaer-Weeze</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Verbandssparkasse Goch-Kevelaer-Weeze</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VSPK_ESCHENB_NEUST</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VSPK Eschenbach i.d.Opf. Neustadt a.d. Waldnaab Vohenstrauß</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VSpk Eschenbach i.d.Opf. Neustadt a.d. Waldnaab Vohenstrauß</p>    </div>  </div></td>
-            <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VSPK_GUNZENHAUSEN</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VSPK Gunzenhausen</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Vereinigte Sparkassen Gunzenhausen</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VVAG_TABLEAU</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VVBeG Tableau Internetseiten</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Vereinigte Volksbanken eG, Böblingen</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VVB_BRAKEL</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VVB Brakel</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Vereinigte Volksbank eG, Brakel</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VVB_DORSTEN</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VVB Dorsten</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Vereinte Volksbank eG, Dorsten</p>    </div>  </div></td>


### PR DESCRIPTION
Release `2.7.10`

- Update Bauspartarife to version `1.70`. This deprecates some tariffs for Bausparkasse Wüstenrot.
- Update Produktanbieter-IDs to version `1.1107`. This adds loan provider `ALLIANZ_RATENSCHUTZ`.