### PR TITLE
Release 2.7.22 - Update Bauspartarife to version 1.82 and Produktanbieter-IDs to version 1.1137

### DIFF
--- a/angebote-openapi.json
+++ b/angebote-openapi.json
@@ -9,7 +9,7 @@
       "url" : "https://developer.europace.de",
       "email" : "devsupport@europace2.de"
     },
-    "version" : "2.7.21"
+    "version" : "2.7.22"
   },
   "externalDocs" : {
     "url" : "https://docs.api.europace.de/baufinanzierung/angebote/angebote-api/"

--- a/angebote-openapi.yaml
+++ b/angebote-openapi.yaml
@@ -7,7 +7,7 @@ info:
     name: Europace AG
     url: https://developer.europace.de
     email: devsupport@europace2.de
-  version: 2.7.21
+  version: 2.7.22
 externalDocs:
   url: https://docs.api.europace.de/baufinanzierung/angebote/angebote-api/
 servers:

--- a/reference/index.html
+++ b/reference/index.html
@@ -2303,7 +2303,7 @@
           <div class="sect2">
             <h3 id="_aktuelle_version">Aktuelle Version</h3>
             <div class="paragraph">
-              <p><em>Version</em> : 2.7.21</p>
+              <p><em>Version</em> : 2.7.22</p>
             </div>
           </div>
         <div class="sect2">
@@ -6187,7 +6187,7 @@
                   <div class="sect4">
                     <h5 id="_beschreibung">Beschreibung</h5>
                     <div class="paragraph">
-                      <p>Die Meldungen eines Finanzierungsvorschlags abrufen. Als Parameter wird die ErmittlungsId und die Ergebnisnummer benötigt.</p>
+                      <p>Die Meldungen eines Finanzierungsvorschlags abrufen. Als Parameter wird die Ermittlungs-Id und die Ergebnisnummer benötigt.</p>
                     </div>
                   </div>
                   <div class="sect4">
@@ -6644,7 +6644,7 @@
                   <div class="sect4">
                     <h5 id="_beschreibung">Beschreibung</h5>
                     <div class="paragraph">
-                      <p>Abruf der Provision des Darlehens. Als Parameter wird die ErmittlungsId und die Ergebnisnummer benötigt.</p>
+                      <p>Abruf der Provision des Darlehens. Als Parameter wird die Ermittlungs-Id und die Ergebnisnummer benötigt.</p>
                     </div>
                   </div>
                   <div class="sect4">
@@ -7137,7 +7137,7 @@
                   <div class="sect4">
                     <h5 id="_beschreibung">Beschreibung</h5>
                     <div class="paragraph">
-                      <p>Abrufen der benötigten Unterlagen des Finanzierungsvorschlags. Als Parameter wird die ErmittlungsId und die Ergebnisnummer benötigt.</p>
+                      <p>Abrufen der benötigten Unterlagen des Finanzierungsvorschlags. Als Parameter wird die Ermittlungs-Id und die Ergebnisnummer benötigt.</p>
                     </div>
                   </div>
                   <div class="sect4">
@@ -30737,6 +30737,7 @@
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>SPK_ST_BLASIEN</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Spk St. Blasien</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Sparkasse St. Blasien</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>SPK_SUEDHOLSTEIN</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Spk Südholstein</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Sparkasse Südholstein</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>SPK_SUEDHOLSTEIN_EV</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Spk Südholstein Eigenvertrieb</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Sparkasse Südholstein Eigenvertrieb</p>    </div>  </div></td>
+            <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>SPK_SUEDWESTPFALZ</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Spk Südwestpfalz Pirmasens-Zweibrücken</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Sparkasse Südwestpfalz Pirmasens-Zweibrücken</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>SPK_SUED_WEINSTRASSE</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Spk Südliche Weinstraße</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Sparkasse Südliche Weinstraße</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>SPK_TAUBERFRANKEN</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Spk Tauberfranken</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Sparkasse Tauberfranken</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>SPK_TAUNUS</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Taunus Sparkasse</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Taunus Sparkasse</p>    </div>  </div></td>
@@ -30998,6 +30999,7 @@
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VOBA_PFORZHEIM</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VoBa Pforzheim</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Volksbank Pforzheim eG</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VOBA_PINNEBERG</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VRB in Holstein</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VR Bank in Holstein eG</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VOBA_PIRNA</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VoBa Pirna</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Volksbank Pirna eG</p>    </div>  </div></td>
+            <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VOBA_PLOCHINGEN</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Volksbank Plochingen eG</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Volksbank Plochingen eG</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VOBA_POMMERN</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Voba Vorpommern</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Volksbank Vorpommern eG</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VOBA_REMSCHEID_SOLINGEN</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>VoBa im Bergischen Land</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Volksbank im Bergischen Land eG</p>    </div>  </div></td>
             <tr><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p><code>VOBA_REMSECK</code></p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Volksbank Remseck eG</p>    </div>  </div></td><td class="tableblock halign-left valign-middle">  <div class="content">    <div class="paragraph">      <p>Volksbank Remseck eG</p>    </div>  </div></td>


### PR DESCRIPTION
Release `2.7.22`

- Update Bauspartarife to version `1.82`.
- Update Produktanbieter-Ids to version `1.1137`. This adds loan providers `SPK_SUEDWESTPFALZ`, `VOBA_PLOCHINGEN`