### PR TITLE
Doc: fix typo in example call route

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If no body is given default parameters are used.
 ```
 
 ``` http
-POST /v3/vorgeange/{{case-id}}/ergebnisliste HTTP/1.1
+POST /v3/vorgae
 Host: api.europace2.de
 Content-Type: application/json
 Authorization: Bearer {{access-token}}


### PR DESCRIPTION
typo in example call route should be fixed